### PR TITLE
include `TLine.h` to compile with C++14 / ROOT v6.24

### DIFF
--- a/src/TRestDetectorSingleChannelAnalysisProcess.cxx
+++ b/src/TRestDetectorSingleChannelAnalysisProcess.cxx
@@ -22,6 +22,7 @@
 #include <TPaveText.h>
 #include <TRandom.h>
 #include <TSpectrum.h>
+#include <TLine.h>
 using namespace std;
 
 ClassImp(TRestDetectorSingleChannelAnalysisProcess)


### PR DESCRIPTION
Related to
https://github.com/rest-for-physics/framework/pull/27
this is another showstopper for the latest ROOT release / C++14.

On this version it complains without it:

```
/home/basti/src/rest_framework/source/libraries/detector/src/TRestDetectorSingleChannelAnalysisProcess.cxx: In member function 'void TRestDetectorSingleChann
elAnalysisProcess::PrintChannelSpectrums(std::string)':
/home/basti/src/rest_framework/source/libraries/detector/src/TRestDetectorSingleChannelAnalysisProcess.cxx:274:11: error: variable 'TLine pLine' has initiali
zer but incomplete type
  274 |     TLine pLine = TLine();
      |           ^~~~~
/home/basti/src/rest_framework/source/libraries/detector/src/TRestDetectorSingleChannelAnalysisProcess.cxx:274:25: error: invalid use of incomplete type 'cla
ss TLine'
  274 |     TLine pLine = TLine();
      |                         ^
In file included from /home/basti/src/rest_framework/source/libraries/detector/src/TRestDetectorSingleChannelAnalysisProcess.cxx:22:
/home/basti/src/root/root/install/include/TPaveText.h:19:7: note: forward declaration of 'class TLine'
   19 | class TLine;
      |       ^~~~~
make[2]: *** [source/libraries/detector/CMakeFiles/RestDetector.dir/build.make:722: source/libraries/detector/CMakeFiles/RestDetector.dir/src/TRestDetectorSi
ngleChannelAnalysisProcess.cxx.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:277: source/libraries/detector/CMakeFiles/RestDetector.dir/all] Error 2
make: *** [Makefile:149: all] Error 2
```