### PR TITLE
.gitlab-ci.yml - Updated Docker image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: lobis/root-geant4-garfieldpp:cxx14_ROOTv6-22-08_Geant4v10.4.3
+image: lobis/root-geant4-garfieldpp:cxx14_ROOTv6-25-01_Geant4v10.4.3
 
 stages:
   - pre-build


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![1](https://badgen.net/badge/Size/1/orange) [![](https://gitlab.cern.ch/rest-for-physics/detectorlib/badges/lobis-patch-1/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/detectorlib/-/commits/lobis-patch-1) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

I don't think this branch should be protected, as we discussed yesterday. (if it should be protected, then restG4 should be too).