### PR TITLE
TRestReadout handles correctly for non-90 deg rotation

### DIFF
--- a/src/TRestDetectorReadoutPlane.cxx
+++ b/src/TRestDetectorReadoutPlane.cxx
@@ -155,6 +155,8 @@ Double_t TRestDetectorReadoutPlane::GetX(Int_t modID, Int_t chID) {
                 if (deltaY < deltaX) x = rModule->GetPixelCenter(chID, 0).X();
             }
         } else {
+            // we choose to ouput x only when deltaY > deltaX under non-90 deg rotation
+            // otherwise it is a y channel and should return nan
             if (deltaY > deltaX) x = rModule->GetPixelCenter(chID, 0).X();
         }
     }
@@ -224,7 +226,9 @@ Double_t TRestDetectorReadoutPlane::GetY(Int_t modID, Int_t chID) {
                 if (deltaY > deltaX) y = rModule->GetPixelCenter(chID, 0).Y();
             }
         } else {
-            if (deltaY < deltaX) y = rModule->GetPixelCenter(chID, 0).X();
+            // we choose to ouput y only when deltaY < deltaX under non-90 deg rotation
+            // otherwise it is a x channel and should return nan
+            if (deltaY < deltaX) y = rModule->GetPixelCenter(chID, 0).Y();
         }
     }
 


### PR DESCRIPTION
![nkx111](https://badgen.net/badge/PR%20submitted%20by%3A/nkx111/blue) ![5](https://badgen.net/badge/Size/5/orange) [![](https://gitlab.cern.ch/rest-for-physics/detectorlib/badges/nkx111-patch-1/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/detectorlib/-/commits/nkx111-patch-1) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

It was a very old bug maybe due to typo error. The code of `TRestReadoutPlane::GetX()` and `TRestReadoutPlane::GetY()` was not symmetric previously for on-90 deg rotation.