### PR TITLE
REST_Detector_CheckReadout updates

### DIFF
--- a/macros/REST_Detector_CheckReadout.C
+++ b/macros/REST_Detector_CheckReadout.C
@@ -13,9 +13,28 @@ TGraph* GetHittedStripMap(TRestDetectorReadoutPlane* p, Int_t mask[4], Double_t 
 
 //*******************************************************************************************************
 //***
-//*** Your HELP is needed to verify, validate and document this macro
-//*** This macro might need update/revision.
-//***
+//*** The following macro allows to perform tests to validate the proper readout construction. It
+//*** will produce Monte Carlo generated positions on the a specific region of the readout plane
+//*** definition, mapping the full active area of the detector to a region of area unity.
+//*** ---
+//*** A 128-bits mask allows to enable the channels we want to be tested. I.e. only Monte Carlo
+//*** generated positions falling at the enabled channels will be drawn. Therefore, this macro is now
+//*** limited to readouts with only 128-channels. A solution, if needed, would be to add an additional
+//*** offset to shift the 128-channels mask.
+//*** ---
+//*** See also github.com/rest-for-physics/basic-readouts
+//*** ---
+//*** A region at the top-left bottom corner of the detector would be defined as:
+//*** Double_t region[4]; region[0] = 0.0; region[1] = 0.5; region[2] = 0.5; region = 1.0;
+//*** ---
+//*** A mask enabling just channels from 72 to 80 would be defined as:
+//*** Int_t mask[4]; mask[0] = 0x0; mask[1] = 0x0; mask[2] = 0xFF00; mask[3] = 0x0;
+//*** ---
+//*** A root file containing a TRestReadoutDetector with its name should be provided in the two first
+//*** arguments. Optional arguments allow to control the statistics and the readout plane index where
+//*** tests will be executed.
+//*** ---
+//*** Usage: restManager Detector_CheckReadout readouts.root readoutName region mask [N] [plane]
 //*******************************************************************************************************
 Int_t REST_Detector_CheckReadout(TString rootFile, TString name, Double_t region[4], Int_t stripsMask[4],
                                  Int_t N = 1E4, Int_t plane = 0) {

--- a/macros/REST_Detector_CheckReadout.C
+++ b/macros/REST_Detector_CheckReadout.C
@@ -32,14 +32,18 @@ TGraph* GetHittedStripMap(TRestDetectorReadoutPlane* p, Int_t mask[4], Double_t 
 //*** A mask enabling just channels from 72 to 80 would be defined as:
 //*** Int_t mask[4]; mask[0] = 0x0; mask[1] = 0x0; mask[2] = 0xFF00; mask[3] = 0x0;
 //*** ---
+//*** The 128-bits mask might be shifted by a given offset, so that the first mask channel is identified
+//*** with that offset
+//*** ---
 //*** A root file containing a TRestReadoutDetector with its name should be provided in the two first
 //*** arguments. Optional arguments allow to control the statistics and the readout plane index where
 //*** tests will be executed.
 //*** ---
-//*** Usage: restManager Detector_CheckReadout readouts.root readoutName region mask [N] [plane]
+//*** Usage: restManager Detector_CheckReadout readouts.root readoutName region mask [offset] [N] [plane]
+//***
 //*******************************************************************************************************
 Int_t REST_Detector_CheckReadout(TString rootFile, TString name, Double_t region[4], Int_t stripsMask[4],
-                                 Int_t N = 1E4, Int_t plane = 0, Int_t offset = 0) {
+                                 Int_t offset = 0, Int_t N = 1E4, Int_t plane = 0) {
     TFile* f = new TFile(rootFile);
     TRestDetectorReadout* readout = (TRestDetectorReadout*)f->Get(name);
     readout->PrintMetadata();

--- a/macros/REST_Detector_CheckReadout.C
+++ b/macros/REST_Detector_CheckReadout.C
@@ -6,7 +6,8 @@
 #include <iostream>
 using namespace std;
 
-TGraph* GetHittedStripMap(TRestDetectorReadoutPlane* p, Int_t mask[4], Double_t region[4], Int_t N);
+TGraph* GetHittedStripMap(TRestDetectorReadoutPlane* p, Int_t mask[4], Double_t region[4], Int_t N,
+                          Int_t offset);
 
 #ifndef RESTTask_CheckReadout
 #define RESTTask_CheckReadout
@@ -38,7 +39,7 @@ TGraph* GetHittedStripMap(TRestDetectorReadoutPlane* p, Int_t mask[4], Double_t 
 //*** Usage: restManager Detector_CheckReadout readouts.root readoutName region mask [N] [plane]
 //*******************************************************************************************************
 Int_t REST_Detector_CheckReadout(TString rootFile, TString name, Double_t region[4], Int_t stripsMask[4],
-                                 Int_t N = 1E4, Int_t plane = 0) {
+                                 Int_t N = 1E4, Int_t plane = 0, Int_t offset = 0) {
     TFile* f = new TFile(rootFile);
     TRestDetectorReadout* readout = (TRestDetectorReadout*)f->Get(name);
     readout->PrintMetadata();
@@ -125,7 +126,7 @@ Int_t REST_Detector_CheckReadout(TString rootFile, TString name, Double_t region
     c->DrawFrame(xmin, ymin, xmax, ymax);
     c->SetTicks();
 
-    GetHittedStripMap(readoutPlane, stripsMask, region, N)->Draw("Psame");
+    GetHittedStripMap(readoutPlane, stripsMask, region, N, offset)->Draw("Psame");
 
     for (int i = 0; i < modGraphID; i++) modGraph[i]->Draw("same");
 
@@ -134,13 +135,16 @@ Int_t REST_Detector_CheckReadout(TString rootFile, TString name, Double_t region
     return 0;
 }
 
-TGraph* GetHittedStripMap(TRestDetectorReadoutPlane* p, Int_t mask[4], Double_t region[4], Int_t N) {
+TGraph* GetHittedStripMap(TRestDetectorReadoutPlane* p, Int_t mask[4], Double_t region[4], Int_t N,
+                          Int_t offset) {
     Double_t xmin, xmax, ymin, ymax;
 
     p->GetBoundaries(xmin, xmax, ymin, ymax);
 
-    cout << "Xmax : " << xmax << " Xmin : " << xmin << endl;
-    cout << "Ymax : " << ymax << " Ymin : " << ymin << endl;
+    cout << "Readout plane boundaries" << endl;
+    cout << "------------------------" << endl;
+    cout << "Xmin : " << xmin << " Xmax : " << xmax << endl;
+    cout << "Ymin : " << ymin << " Ymax : " << ymax << endl;
 
     cout << "region 1 : " << region[0] << endl;
     cout << "region 2 : " << region[1] << endl;
@@ -153,8 +157,10 @@ TGraph* GetHittedStripMap(TRestDetectorReadoutPlane* p, Int_t mask[4], Double_t 
     Double_t yMin = region[2] * (ymax - ymin) + ymin;
     Double_t yMax = region[3] * (ymax - ymin) + ymin;
 
-    cout << "Xmax : " << xMax << " Xmin : " << xMin << endl;
-    cout << "Ymax : " << yMax << " Ymin : " << yMin << endl;
+    cout << "Region boundaries on plane coordinates" << endl;
+    cout << "--------------------------------------" << endl;
+    cout << "Xmin : " << xMin << " Xmax : " << xMax << endl;
+    cout << "Ymin : " << yMin << " Ymax : " << yMax << endl;
 
     TRandom* rnd = new TRandom();
 
@@ -169,7 +175,7 @@ TGraph* GetHittedStripMap(TRestDetectorReadoutPlane* p, Int_t mask[4], Double_t 
         Int_t msk = 0x1 << bit;
         if (msk & mask[level]) {
             cout << "Adding channel : " << 32 * level + bit << endl;
-            channelIds.push_back(32 * level + bit);
+            channelIds.push_back(32 * level + bit + offset);
         }
     }
 

--- a/macros/REST_Detector_CheckReadout.C
+++ b/macros/REST_Detector_CheckReadout.C
@@ -27,6 +27,7 @@ TGraph* GetHittedStripMap(TRestDetectorReadoutPlane* p, Int_t mask[4], Double_t 
 //*** A region at the top-left bottom corner of the detector would be defined as:
 //*** Double_t region[4]; region[0] = 0.0; region[1] = 0.5; region[2] = 0.5; region = 1.0;
 //*** ---
+//*** The 128-bits mask is split into four 32-bits integer fields identifying each with 32-channels.
 //*** A mask enabling just channels from 72 to 80 would be defined as:
 //*** Int_t mask[4]; mask[0] = 0x0; mask[1] = 0x0; mask[2] = 0xFF00; mask[3] = 0x0;
 //*** ---


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![41](https://badgen.net/badge/Size/41/orange) [![](https://gitlab.cern.ch/rest-for-physics/detectorlib/badges/check_readout_macro/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/detectorlib/-/commits/check_readout_macro) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- Added few lines to document the CheckReadout macro.

It will be shown when executing

```
restManager ListMacros
```

- Added an offset so that we will be able to shift the 128-bits mask to select channels of higher value.