### PR TITLE
Detector signal updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-set( LibraryVersion "1.2" )
+set( LibraryVersion "1.3" )
 add_definitions(-DLIBRARY_VERSION="${LibraryVersion}")
 
 #find garfield libs and includes

--- a/inc/TRestDetectorHitsToSignalProcess.h
+++ b/inc/TRestDetectorHitsToSignalProcess.h
@@ -21,15 +21,11 @@
 
 class TRestDetectorHitsToSignalProcess : public TRestEventProcess {
    private:
-#ifndef __CINT__
     TRestDetectorHitsEvent* fHitsEvent;      //!
     TRestDetectorSignalEvent* fSignalEvent;  //!
 
     TRestDetectorReadout* fReadout;  //!
     TRestDetectorGas* fGas;          //!
-#endif
-
-    void InitFromConfigFile();
 
     void Initialize();
 

--- a/src/TRestDetectorHitsToSignalProcess.cxx
+++ b/src/TRestDetectorHitsToSignalProcess.cxx
@@ -212,14 +212,3 @@ void TRestDetectorHitsToSignalProcess::EndProcess() {
     // Comment this if you don't want it.
     // TRestEventProcess::EndProcess();
 }
-
-//______________________________________________________________________________
-void TRestDetectorHitsToSignalProcess::InitFromConfigFile() {
-    fSampling = GetDblParameterWithUnits("sampling");
-    // returned in REST standard unit: atm
-    fGasPressure = GetDblParameterWithUnits("gasPressure", -1.);
-    // convert REST standard unit "V/mm" to "V/cm"
-    fElectricField = GetDblParameterWithUnits("electricField", -1.);
-    // DONE : velocity units are implemented with standard unit "mm/us"
-    fDriftVelocity = GetDblParameterWithUnits("driftVelocity", -1.);
-}


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![1](https://badgen.net/badge/Size/1/orange) [![](https://gitlab.cern.ch/rest-for-physics/detectorlib/badges/detector_signal_updates/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/detectorlib/-/commits/detector_signal_updates) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This updates `TRestDetectorHitsToSignalProcess` in order to use the standard/common configuration parameters in REST.

The change is important because that way we will be able to use for example, statements as `[TRestDetector::fPressure]` at the process parameter definitions.

It also fixes version 1.3 of this library.
