### PR TITLE
Fix installation issue due to Garfield

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,12 +15,12 @@ if (${REST_GARFIELD} MATCHES "ON")
         # find_package(Garfield REQUIRED)
         set(external_include_dirs ${external_include_dirs} ${GARFIELD_INSTALL}/include/Garfield)
         set(external_libs ${external_libs} "-L${GARFIELD_INSTALL}/lib -lGarfield")
-        # recommended CMake way does not work, we need to delete the "FindGarfield.cmake" script4
+        # recommended CMake way does not work, we need to delete the "FindGarfield.cmake" script
     elseif (DEFINED ENV{GARFIELD_HOME})
         # Old way, for backwards compatibility
         message(STATUS "Using old Garfield CMake")
         set(GARFIELD_INSTALL $ENV{GARFIELD_HOME})
-        include(FindGarfield)
+        include(FindGarfieldOld)
         set(external_include_dirs ${external_include_dirs} ${GARFIELD_INSTALL}/Include)
         set(external_include_dirs ${external_include_dirs} ${GARFIELD_INSTALL}/Heed)
         set(external_libs "${external_libs} ${Garfield_LIBRARIES}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,12 @@ if (${REST_GARFIELD} MATCHES "ON")
     add_definitions(-DUSE_Garfield)
 
     if (DEFINED ENV{GARFIELD_INSTALL})
+        # Tested for Garfield af4a14516489babbd6e6df780edd58fedf7fa12b
         message(STATUS "Using new Garfield CMake")
         set(GARFIELD_INSTALL $ENV{GARFIELD_INSTALL})
-        # find_package(Garfield REQUIRED)
+        find_package(Garfield REQUIRED)
         set(external_include_dirs ${external_include_dirs} ${GARFIELD_INSTALL}/include/Garfield)
-        set(external_libs ${external_libs} "-L${GARFIELD_INSTALL}/lib -lGarfield")
+        set(external_libs ${external_libs} Garfield::Garfield)
         # recommended CMake way does not work, we need to delete the "FindGarfield.cmake" script
     elseif (DEFINED ENV{GARFIELD_HOME})
         # Old way, for backwards compatibility


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![5](https://badgen.net/badge/Size/5/orange) [![](https://gitlab.cern.ch/rest-for-physics/detectorlib/badges/lobis-patch-garfield-install-naf-iaxo/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/detectorlib/-/commits/lobis-patch-garfield-install-naf-iaxo)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Using recommended Garfield CMake commands to link it.

On different systems the `lib` folder may be named differently (`lib64`). This is a problem in NAF-IAXO.