### PR TITLE
Removed `using namespace std` from header files and fix errors

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,4 @@
-image: ghcr.io/lobis/root-geant4-garfield:cpp17_ROOT-v6-26-00_Geant4-v10.4.3_Garfield-af4a1451
-# image: nkx1231/root6-geant4-garfield:0.8
+image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
 
 stages:
   - pre-build

--- a/inc/TRestDetector.h
+++ b/inc/TRestDetector.h
@@ -40,8 +40,6 @@
 #include "TRestStringOutput.h"
 #include "TRestTools.h"
 
-
-
 //! An metadata class to store basic detector information
 class TRestDetector : public TRestMetadata {
    public:

--- a/inc/TRestDetector.h
+++ b/inc/TRestDetector.h
@@ -40,13 +40,13 @@
 #include "TRestStringOutput.h"
 #include "TRestTools.h"
 
-using namespace std;
+
 
 //! An metadata class to store basic detector information
 class TRestDetector : public TRestMetadata {
    public:
     /// The detector name
-    string fDetectorName = "REST Detector";
+    std::string fDetectorName = "REST Detector";
 
     /// The detector drift voltage in V
     Double_t fDriftVoltage = -1;
@@ -84,11 +84,11 @@ class TRestDetector : public TRestMetadata {
     Double_t fElectronicsThreshold = -1;
 
     /// The electronics gain in raw configuration format (hexadecimal)
-    string fElectronicsGain = "-1";
+    std::string fElectronicsGain = "-1";
     /// The electronics clock (sampling) in raw configuration format (hexadecimal)
-    string fElectronicsClock = "-1";
+    std::string fElectronicsClock = "-1";
     /// The electronics shaping in raw configuration format (hexadecimal)
-    string fElectronicsShaping = "-1";
+    std::string fElectronicsShaping = "-1";
 
     void InitFromConfigFile() { ReadAllParameters(); }
 

--- a/inc/TRestDetectorDriftVolume.h
+++ b/inc/TRestDetectorDriftVolume.h
@@ -43,7 +43,7 @@
 class TRestDetectorDriftVolume : public TRestMetadata {
    protected:
     std::string fMaterial;  // material description std::string
-    Double_t fW;       // Work function for electron extraction, in unit eV.
+    Double_t fW;            // Work function for electron extraction, in unit eV.
 
     Double_t fElectricField;          // in unit V/mm
     Double_t fDriftVelocity;          // in unit mm/us

--- a/inc/TRestDetectorDriftVolume.h
+++ b/inc/TRestDetectorDriftVolume.h
@@ -42,7 +42,7 @@
 
 class TRestDetectorDriftVolume : public TRestMetadata {
    protected:
-    string fMaterial;  // material description string
+    std::string fMaterial;  // material description std::string
     Double_t fW;       // Work function for electron extraction, in unit eV.
 
     Double_t fElectricField;          // in unit V/mm
@@ -58,11 +58,11 @@ class TRestDetectorDriftVolume : public TRestMetadata {
 
    public:
     TRestDetectorDriftVolume();
-    TRestDetectorDriftVolume(const char* cfgFileName, string name = "");
+    TRestDetectorDriftVolume(const char* cfgFileName, std::string name = "");
     virtual void Initialize();
     virtual void InitFromConfigFile();
 
-    virtual string GetMaterial() { return fMaterial; }
+    virtual std::string GetMaterial() { return fMaterial; }
     virtual Double_t GetW() { return fW; }
     virtual Double_t GetWvalue() { return fW; }
 
@@ -81,7 +81,7 @@ class TRestDetectorDriftVolume : public TRestMetadata {
     virtual Double_t GetPressure() { return fPressureInAtm; }
     virtual Double_t GetTemperature() { return fTemperatureInK; }
 
-    virtual void SetMaterial(string value) { fMaterial = value; }
+    virtual void SetMaterial(std::string value) { fMaterial = value; }
 
     /// Sets the electric field of the drift volume. Given in V/mm.
     virtual void SetW(double value) { fW = value; }

--- a/inc/TRestDetectorGainMap.h
+++ b/inc/TRestDetectorGainMap.h
@@ -49,8 +49,8 @@ class TRestDetectorGainMap : public TRestMetadata {
    public:
     bool relative;
     std::map<int, double> fChannelGain;  // [channel id, gain]
-    TH2F* f2DGainMapping = 0;       //->
-    TH3F* f3DGainMapping = 0;       //->
+    TH2F* f2DGainMapping = 0;            //->
+    TH3F* f3DGainMapping = 0;            //->
 
     void InitFromConfigFile();
 

--- a/inc/TRestDetectorGainMap.h
+++ b/inc/TRestDetectorGainMap.h
@@ -48,14 +48,14 @@ class TRestDetectorReadout;
 class TRestDetectorGainMap : public TRestMetadata {
    public:
     bool relative;
-    map<int, double> fChannelGain;  // [channel id, gain]
+    std::map<int, double> fChannelGain;  // [channel id, gain]
     TH2F* f2DGainMapping = 0;       //->
     TH3F* f3DGainMapping = 0;       //->
 
     void InitFromConfigFile();
 
-    void SaveToText(string filename) {}
-    void ReadGainText(string filename) {}
+    void SaveToText(std::string filename) {}
+    void ReadGainText(std::string filename) {}
 
     void DrawChannelGainMap(TRestDetectorReadoutModule* mod = 0);
 

--- a/inc/TRestDetectorGas.h
+++ b/inc/TRestDetectorGas.h
@@ -74,9 +74,9 @@ class TRestDetectorGas : public TRestDetectorDriftVolume {
     Double_t fMaxElectronEnergy;  // Maximum electron energy, in eV, used in
                                   // Magboltz gas calculation.
 
-    std::vector<TString> fGasComponentName;       // A string vector storing the names
+    std::vector<TString> fGasComponentName;       // A std::string std::vector storing the names
                                                   // of each of the gas components
-    std::vector<Double_t> fGasComponentFraction;  // A double vector storing the fraction values of
+    std::vector<Double_t> fGasComponentFraction;  // A double std::vector storing the fraction values of
                                                   // each of the gas components
 
     Int_t fEnodes;   // Number of electric field nodes used in the gas calculation.
@@ -98,7 +98,7 @@ class TRestDetectorGas : public TRestDetectorDriftVolume {
                           //!             gas file is not found, it will allow to
                           //!             launch the gas generation.
 
-    TString fGasOutputPath;  //!          A string to store the output path where
+    TString fGasOutputPath;  //!          A std::string to store the output path where
                              //!          a new generated gas file will be written
 
     TString fGasServer;  //!              The remote server from where we retrieve
@@ -110,13 +110,13 @@ class TRestDetectorGas : public TRestDetectorDriftVolume {
     Bool_t fTest = false;  //!
 
     void InitFromConfigFile();
-    string ConstructFilename();
+    std::string ConstructFilename();
 
     void AddGasComponent(std::string gasName, Double_t fraction);
 
     void GenerateGasFile();
 
-    void UploadGasToServer(string gasFilename);
+    void UploadGasToServer(std::string gasFilename);
 
     Double_t GetDriftVelocity(Double_t E);
     Double_t GetLongitudinalDiffusion(Double_t E);
@@ -126,7 +126,7 @@ class TRestDetectorGas : public TRestDetectorDriftVolume {
 
    public:
     TRestDetectorGas();
-    TRestDetectorGas(const char* cfgFileName, string name = "", bool gasGeneration = false,
+    TRestDetectorGas(const char* cfgFileName, std::string name = "", bool gasGeneration = false,
                      bool test = false);
     ~TRestDetectorGas();
 
@@ -144,7 +144,7 @@ class TRestDetectorGas : public TRestDetectorDriftVolume {
 
     void LoadGasFile();
 
-    string FindGasFile(string name);
+    std::string FindGasFile(std::string name);
 
     void CalcGarField(double Emin, double Emax, int n);
 
@@ -162,7 +162,7 @@ class TRestDetectorGas : public TRestDetectorDriftVolume {
     /// Returns the gas component *n*.
     TString GetGasComponentName(Int_t n) {
         if (n >= GetNofGases()) {
-            cout << "REST WARNING. Gas name component n=" << n << " requested. But only " << GetNofGases()
+            std::cout << "REST WARNING. Gas name component n=" << n << " requested. But only " << GetNofGases()
                  << " component(s) in the mixture." << endl;
             return "";
         }
@@ -223,7 +223,7 @@ class TRestDetectorGas : public TRestDetectorDriftVolume {
     /// Returns the gas fraction in volume for component *n*.
     Double_t GetGasComponentFraction(Int_t n) {
         if (n >= GetNofGases()) {
-            cout << "REST WARNING. Gas fraction for component n=" << n << " requested. But only "
+            std::cout << "REST WARNING. Gas fraction for component n=" << n << " requested. But only "
                  << GetNofGases() << " component(s) in the mixture." << endl;
             return 0.;
         }
@@ -250,7 +250,7 @@ class TRestDetectorGas : public TRestDetectorDriftVolume {
     void PlotTransversalDiffusion(Double_t eMin, Double_t eMax, Int_t nSteps);
     void PlotTownsendCoefficient(Double_t eMin, Double_t eMax, Int_t nSteps);
     void PrintGasInfo();
-    void PrintGasFileContent() { cout << fGasFileContent << endl; };
+    void PrintGasFileContent() { std::cout << fGasFileContent << endl; };
 
     /// Prints the metadata information from the gas
     void PrintMetadata() { PrintGasInfo(); }

--- a/inc/TRestDetectorGas.h
+++ b/inc/TRestDetectorGas.h
@@ -162,8 +162,8 @@ class TRestDetectorGas : public TRestDetectorDriftVolume {
     /// Returns the gas component *n*.
     TString GetGasComponentName(Int_t n) {
         if (n >= GetNofGases()) {
-            std::cout << "REST WARNING. Gas name component n=" << n << " requested. But only " << GetNofGases()
-                 << " component(s) in the mixture." << endl;
+            std::cout << "REST WARNING. Gas name component n=" << n << " requested. But only "
+                      << GetNofGases() << " component(s) in the mixture." << endl;
             return "";
         }
         return fGasComponentName[n];
@@ -224,7 +224,7 @@ class TRestDetectorGas : public TRestDetectorDriftVolume {
     Double_t GetGasComponentFraction(Int_t n) {
         if (n >= GetNofGases()) {
             std::cout << "REST WARNING. Gas fraction for component n=" << n << " requested. But only "
-                 << GetNofGases() << " component(s) in the mixture." << endl;
+                      << GetNofGases() << " component(s) in the mixture." << endl;
             return 0.;
         }
 

--- a/inc/TRestDetectorGeometry.h
+++ b/inc/TRestDetectorGeometry.h
@@ -45,16 +45,14 @@ typedef Garfield::Component Component;
 
 #endif
 
-
-
 class TRestDetectorGeometry : public TGeoManager {
    protected:
 #if defined USE_Garfield
-    Garfield::GeometryRoot* fGfGeometry;  //!///< Pointer to Garfield::GeometryRoot object of the
-                                          //! geometry
+    Garfield::GeometryRoot* fGfGeometry;       //!///< Pointer to Garfield::GeometryRoot object of the
+                                               //! geometry
     std::vector<Component*> vGfComponent;      //!///< Vector of pointers to Garfield Component object
     std::vector<Garfield::Sensor*> vGfSensor;  //!///< Vector of pointers to Garfield Sensor object
-    TGeoNode* fDriftElec;                 //!///< pointer to drift electrode
+    TGeoNode* fDriftElec;                      //!///< pointer to drift electrode
     std::vector<TGeoNode*> vReadoutElec;       //!///< std::vector of pointers to readout planes
 
 #endif

--- a/inc/TRestDetectorGeometry.h
+++ b/inc/TRestDetectorGeometry.h
@@ -45,17 +45,17 @@ typedef Garfield::Component Component;
 
 #endif
 
-using namespace std;
+
 
 class TRestDetectorGeometry : public TGeoManager {
    protected:
 #if defined USE_Garfield
     Garfield::GeometryRoot* fGfGeometry;  //!///< Pointer to Garfield::GeometryRoot object of the
                                           //! geometry
-    vector<Component*> vGfComponent;      //!///< Vector of pointers to Garfield Component object
-    vector<Garfield::Sensor*> vGfSensor;  //!///< Vector of pointers to Garfield Sensor object
+    std::vector<Component*> vGfComponent;      //!///< Vector of pointers to Garfield Component object
+    std::vector<Garfield::Sensor*> vGfSensor;  //!///< Vector of pointers to Garfield Sensor object
     TGeoNode* fDriftElec;                 //!///< pointer to drift electrode
-    vector<TGeoNode*> vReadoutElec;       //!///< vector of pointers to readout planes
+    std::vector<TGeoNode*> vReadoutElec;       //!///< std::vector of pointers to readout planes
 
 #endif
 

--- a/inc/TRestDetectorHitsAnalysisProcess.h
+++ b/inc/TRestDetectorHitsAnalysisProcess.h
@@ -23,10 +23,8 @@
 #ifndef RestCore_TRestDetectorHitsAnalysisProcess
 #define RestCore_TRestDetectorHitsAnalysisProcess
 
-#include <TH1D.h>
-
 #include <TCanvas.h>
-
+#include <TH1D.h>
 #include <TRestDetectorGas.h>
 #include <TRestDetectorHitsEvent.h>
 #include <TRestDetectorReadout.h>

--- a/inc/TRestDetectorHitsEvent.h
+++ b/inc/TRestDetectorHitsEvent.h
@@ -2,6 +2,8 @@
 #ifndef TRestSoft_TRestDetectorHitsEvent
 #define TRestSoft_TRestDetectorHitsEvent
 
+#include <TGraph.h>
+
 #include <iostream>
 
 #include "TArrayI.h"
@@ -10,12 +12,6 @@
 #include "TH2F.h"
 #include "TMath.h"
 #include "TObject.h"
-
-#include <TGraph.h>
-#include "TH2F.h"
-
-#include "TVector3.h"
-
 #include "TRestEvent.h"
 #include "TRestHits.h"
 #include "TVector3.h"

--- a/inc/TRestDetectorHitsEvent.h
+++ b/inc/TRestDetectorHitsEvent.h
@@ -20,7 +20,7 @@
 #include "TRestHits.h"
 #include "TVector3.h"
 
-//! An event data type that register a vector of TRestHits,
+//! An event data type that register a std::vector of TRestHits,
 //! allowing us to save a 3-coordinate position and energy.
 class TRestDetectorHitsEvent : public TRestEvent {
    private:

--- a/inc/TRestDetectorHitsEventViewer.h
+++ b/inc/TRestDetectorHitsEventViewer.h
@@ -15,9 +15,8 @@
 #ifndef RestCore_TRestDetectorHitsEventViewer
 #define RestCore_TRestDetectorHitsEventViewer
 
-#include "TRestEveEventViewer.h"
-
 #include "TRestDetectorHitsEvent.h"
+#include "TRestEveEventViewer.h"
 
 class TRestDetectorHitsEventViewer : public TRestEveEventViewer {
    private:

--- a/inc/TRestDetectorHitsGaussAnalysisProcess.h
+++ b/inc/TRestDetectorHitsGaussAnalysisProcess.h
@@ -23,10 +23,8 @@
 #ifndef RestCore_TRestDetectorHitsGaussAnalysisProcess
 #define RestCore_TRestDetectorHitsGaussAnalysisProcess
 
-#include <TH1D.h>
-
 #include <TCanvas.h>
-
+#include <TH1D.h>
 #include <TRestDetectorGas.h>
 #include <TRestDetectorHitsEvent.h>
 #include <TRestDetectorReadout.h>

--- a/inc/TRestDetectorHitsReductionProcess.h
+++ b/inc/TRestDetectorHitsReductionProcess.h
@@ -12,6 +12,7 @@
 #define RestCore_TRestDetectorHitsReductionProcess
 
 #include <TRestDetectorHitsEvent.h>
+
 #include "TRestEventProcess.h"
 
 class TRestDetectorHitsReductionProcess : public TRestEventProcess {

--- a/inc/TRestDetectorHitsSmearingProcess.h
+++ b/inc/TRestDetectorHitsSmearingProcess.h
@@ -16,10 +16,9 @@
 #ifndef RestCore_TRestDetectorHitsSmearingProcess
 #define RestCore_TRestDetectorHitsSmearingProcess
 
+#include <TRandom3.h>
 #include <TRestDetectorGas.h>
 #include <TRestDetectorHitsEvent.h>
-
-#include <TRandom3.h>
 
 #include "TRestEventProcess.h"
 

--- a/inc/TRestDetectorPositionMappingProcess.h
+++ b/inc/TRestDetectorPositionMappingProcess.h
@@ -37,7 +37,7 @@ class TRestDetectorPositionMappingProcess : public TRestEventProcess {
     bool fCreateGainMap;
     TVector2 fEnergyCutRange;
     TVector2 fNHitsCutRange;
-    string fMappingSave;
+    std::string fMappingSave;
 
     double fNBinsX;
     double fNBinsY;
@@ -65,9 +65,9 @@ class TRestDetectorPositionMappingProcess : public TRestEventProcess {
         BeginPrintProcess();
 
         metadata << "the mode is:" << endl;
-        metadata << (fApplyGainCorrection ? ">   " : "    ") << "Apply position correction map for spectrum "
+        metadata << (fApplyGainCorrection ? ">   " : "    ") << "Apply position correction std::map for spectrum "
                  << endl;
-        metadata << (fCreateGainMap ? ">   " : "    ") << "Create new correction map for each position"
+        metadata << (fCreateGainMap ? ">   " : "    ") << "Create new correction std::map for each position"
                  << endl;
         metadata << "output mapping file: " << fMappingSave << endl;
         metadata << "Energy cut for Threshold integral: " << any(fEnergyCutRange) << endl;

--- a/inc/TRestDetectorPositionMappingProcess.h
+++ b/inc/TRestDetectorPositionMappingProcess.h
@@ -13,7 +13,6 @@
 #define RestCore_TRestDetectorPositionMappingProcess
 
 #include <TH1D.h>
-
 #include <TRestDetectorGas.h>
 #include <TRestDetectorHitsEvent.h>
 #include <TRestDetectorReadout.h>
@@ -65,8 +64,8 @@ class TRestDetectorPositionMappingProcess : public TRestEventProcess {
         BeginPrintProcess();
 
         metadata << "the mode is:" << endl;
-        metadata << (fApplyGainCorrection ? ">   " : "    ") << "Apply position correction std::map for spectrum "
-                 << endl;
+        metadata << (fApplyGainCorrection ? ">   " : "    ")
+                 << "Apply position correction std::map for spectrum " << endl;
         metadata << (fCreateGainMap ? ">   " : "    ") << "Create new correction std::map for each position"
                  << endl;
         metadata << "output mapping file: " << fMappingSave << endl;

--- a/inc/TRestDetectorReadout.h
+++ b/inc/TRestDetectorReadout.h
@@ -42,12 +42,12 @@ class TRestDetectorReadout : public TRestMetadata {
 
     Int_t fNReadoutPlanes;  ///< Number of readout planes present on the readout
     std::vector<TRestDetectorReadoutPlane>
-        fReadoutPlanes;  ///< A vector storing the TRestDetectorReadoutPlane definitions.
+        fReadoutPlanes;  ///< A std::vector storing the TRestDetectorReadoutPlane definitions.
 
 #ifndef __CINT__
     Int_t fMappingNodes;  //!///< Number of nodes per axis used on the readout
                           //! coordinate mapping. See also TRestDetectorReadoutMapping.
-    vector<TRestDetectorReadoutModule> fModuleDefinitions;  //!///< A vector storing the different
+    std::vector<TRestDetectorReadoutModule> fModuleDefinitions;  //!///< A std::vector storing the different
                                                             //! TRestDetectorReadoutModule definitions.
 #endif
 

--- a/inc/TRestDetectorReadout.h
+++ b/inc/TRestDetectorReadout.h
@@ -26,7 +26,6 @@
 #include <iostream>
 
 #include "TObject.h"
-
 #include "TRestDetectorReadoutPlane.h"
 #include "TRestMetadata.h"
 
@@ -48,7 +47,7 @@ class TRestDetectorReadout : public TRestMetadata {
     Int_t fMappingNodes;  //!///< Number of nodes per axis used on the readout
                           //! coordinate mapping. See also TRestDetectorReadoutMapping.
     std::vector<TRestDetectorReadoutModule> fModuleDefinitions;  //!///< A std::vector storing the different
-                                                            //! TRestDetectorReadoutModule definitions.
+                                                                 //! TRestDetectorReadoutModule definitions.
 #endif
 
     void ValidateReadout();

--- a/inc/TRestDetectorReadoutChannel.h
+++ b/inc/TRestDetectorReadoutChannel.h
@@ -46,7 +46,7 @@ class TRestDetectorReadoutChannel : public TObject {
    private:
     Int_t fDaqID;  ///< Defines the corresponding daq channel id. See decoding
                    ///< details at TRestDetectorReadout.
-    std::vector<TRestDetectorReadoutPixel> fReadoutPixel;  ///< A vector storing the different
+    std::vector<TRestDetectorReadoutPixel> fReadoutPixel;  ///< A std::vector storing the different
                                                            ///< TRestDetectorReadoutPixel definitions.
 
     Short_t fChannelId = -1;  ///< It stores the corresponding physical readout channel

--- a/inc/TRestDetectorReadoutChannel.h
+++ b/inc/TRestDetectorReadoutChannel.h
@@ -26,9 +26,8 @@
 #include <iostream>
 
 #include "TObject.h"
-#include "TRestMetadata.h"
-
 #include "TRestDetectorReadoutPixel.h"
+#include "TRestMetadata.h"
 
 enum TRestDetectorReadoutChannelType {
     Channel_NoType = 0,

--- a/inc/TRestDetectorReadoutMapping.h
+++ b/inc/TRestDetectorReadoutMapping.h
@@ -23,10 +23,10 @@
 #ifndef RestCore_TRestDetectorReadoutMapping
 #define RestCore_TRestDetectorReadoutMapping
 
-#include <iostream>
-
 #include <TMatrixD.h>
 #include <TObject.h>
+
+#include <iostream>
 
 /// This class defines a uniform 2-dimensional grid relating its nodes to the
 /// pixels of a readout.

--- a/inc/TRestDetectorReadoutModule.h
+++ b/inc/TRestDetectorReadoutModule.h
@@ -23,14 +23,14 @@
 #ifndef RestCore_TRestDetectorReadoutModule
 #define RestCore_TRestDetectorReadoutModule
 
-#include <iostream>
-
 #include <TMath.h>
-#include "TObject.h"
-
 #include <TRestDetectorReadoutChannel.h>
 #include <TRestDetectorReadoutMapping.h>
 #include <TVector2.h>
+
+#include <iostream>
+
+#include "TObject.h"
 
 /// A class to store the readout module definition used in TRestDetectorReadoutPlane. It
 /// allows to integrate any number of independent readout channels.

--- a/inc/TRestDetectorReadoutModule.h
+++ b/inc/TRestDetectorReadoutModule.h
@@ -59,7 +59,7 @@ class TRestDetectorReadoutModule : public TObject {
     Int_t fMaximumDaqId;    ///< The maximum daq channel id associated to the module.
 
     std::vector<TRestDetectorReadoutChannel>
-        fReadoutChannel;  ///< A vector of the instances of TRestDetectorReadoutChannel
+        fReadoutChannel;  ///< A std::vector of the instances of TRestDetectorReadoutChannel
                           ///< containned in the readout module.
 
     TRestDetectorReadoutMapping fMapping;  ///< The readout module uniform grid mapping.

--- a/inc/TRestDetectorReadoutPixel.h
+++ b/inc/TRestDetectorReadoutPixel.h
@@ -23,10 +23,11 @@
 #ifndef RestCore_TRestDetectorReadoutPixel
 #define RestCore_TRestDetectorReadoutPixel
 
-#include <iostream>
-
 #include <TMath.h>
 #include <TVector2.h>
+
+#include <iostream>
+
 #include "TObject.h"
 #include "TRestMetadata.h"
 

--- a/inc/TRestDetectorReadoutPlane.h
+++ b/inc/TRestDetectorReadoutPlane.h
@@ -43,7 +43,7 @@ class TRestDetectorReadoutPlane : public TObject {
 
     TVector3 fPosition;            ///< The position of the readout plane. The relative position
                                    ///< of the modules will be shifted by this value.
-    TVector3 fPlaneVector;         ///< The plane vector definning the plane orientation
+    TVector3 fPlaneVector;         ///< The plane std::vector definning the plane orientation
                                    ///< and the side of the active volume.
     TVector3 fCathodePosition;     ///< The cathode position which delimites the active
                                    ///< volume together with the readout plane.
@@ -57,7 +57,7 @@ class TRestDetectorReadoutPlane : public TObject {
     Int_t fNModules;  ///< The number of modules that have been added to the
                       ///< readout plane
     std::vector<TRestDetectorReadoutModule>
-        fReadoutModules;  ///< A vector of the instances of TRestDetectorReadoutModule
+        fReadoutModules;  ///< A std::vector of the instances of TRestDetectorReadoutModule
                           ///< containned in the readout plane.
 
     void Initialize();
@@ -95,7 +95,7 @@ class TRestDetectorReadoutPlane : public TObject {
     /// Returns a TVector3 with the cathode position
     TVector3 GetCathodePosition() { return fCathodePosition; }
 
-    /// Returns a TVector3 with a vector normal to the readout plane
+    /// Returns a TVector3 with a std::vector normal to the readout plane
     TVector3 GetPlaneVector() { return fPlaneVector; }
 
     /// Returns the charge collection ratio at this readout plane
@@ -120,7 +120,7 @@ class TRestDetectorReadoutPlane : public TObject {
 
     TRestDetectorReadoutModule& operator[](int mod) { return fReadoutModules[mod]; }
 
-    /// Returns a pointer to a readout module using its vector index
+    /// Returns a pointer to a readout module using its std::vector index
     TRestDetectorReadoutModule* GetModule(int mod) {
         if (mod >= GetNumberOfModules()) return NULL;
         return &fReadoutModules[mod];

--- a/inc/TRestDetectorReadoutPlane.h
+++ b/inc/TRestDetectorReadoutPlane.h
@@ -23,16 +23,15 @@
 #ifndef RestCore_TRestDetectorReadoutPlane
 #define RestCore_TRestDetectorReadoutPlane
 
+#include <TGraph.h>
+#include <TH2Poly.h>
+
 #include <iostream>
 
 #include "TObject.h"
-
 #include "TRestDetectorReadoutChannel.h"
 #include "TRestDetectorReadoutModule.h"
 #include "TRestMetadata.h"
-
-#include <TGraph.h>
-#include <TH2Poly.h>
 
 /// A class to store the readout plane definition used in TRestDetectorReadout. It
 /// allows to integrate any number of independent readout modules.

--- a/inc/TRestDetectorSetup.h
+++ b/inc/TRestDetectorSetup.h
@@ -15,15 +15,15 @@
 #ifndef RestCore_TRestDetectorSetup
 #define RestCore_TRestDetectorSetup
 
+#include <TRestMetadata.h>
 #include <stdio.h>
 #include <stdlib.h>
+
 #include <cstdio>
 #include <cstring>
 #include <fstream>
 #include <iostream>
 #include <vector>
-
-#include <TRestMetadata.h>
 
 class TRestDetectorSetup : public TRestMetadata {
    private:

--- a/inc/TRestDetectorSignal.h
+++ b/inc/TRestDetectorSignal.h
@@ -22,12 +22,12 @@
 #ifndef RestCore_TRestDetectorSignal
 #define RestCore_TRestDetectorSignal
 
-#include <iostream>
-
 #include <TGraph.h>
 #include <TObject.h>
 #include <TString.h>
 #include <TVector2.h>
+
+#include <iostream>
 
 class TRestDetectorSignal : public TObject {
    private:
@@ -82,7 +82,7 @@ class TRestDetectorSignal : public TObject {
     Int_t GetNumberOfPoints() {
         if (fSignalTime.size() != fSignalCharge.size()) {
             std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl;
-            std::cout << "WARNING, the two vector sizes did not match" << std::endl;
+            std::cout << "WARNING, the two std::vector sizes did not match" << std::endl;
             std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl;
         }
         return fSignalTime.size();

--- a/inc/TRestDetectorSignalChannelActivityProcess.h
+++ b/inc/TRestDetectorSignalChannelActivityProcess.h
@@ -24,7 +24,6 @@
 #define RestCore_TRestDetectorSignalChannelActivityProcess
 
 #include <TH1D.h>
-
 #include <TRestDetectorReadout.h>
 #include <TRestDetectorSignalEvent.h>
 

--- a/inc/TRestDetectorSignalEvent.h
+++ b/inc/TRestDetectorSignalEvent.h
@@ -19,14 +19,14 @@
 #ifndef RestDAQ_TRestDetectorSignalEvent
 #define RestDAQ_TRestDetectorSignalEvent
 
-#include <iostream>
-
 #include <TArrayD.h>
 #include <TAxis.h>
 #include <TGraph.h>
 #include <TMultiGraph.h>
 #include <TObject.h>
 #include <TPad.h>
+
+#include <iostream>
 
 #include "TRestDetectorSignal.h"
 #include "TRestEvent.h"

--- a/inc/TRestDetectorSignalToHitsProcess.h
+++ b/inc/TRestDetectorSignalToHitsProcess.h
@@ -24,9 +24,8 @@
 #define RestCore_TRestDetectorSignalToHitsProcess
 
 #include <TRestDetectorGas.h>
-#include <TRestDetectorReadout.h>
-
 #include <TRestDetectorHitsEvent.h>
+#include <TRestDetectorReadout.h>
 #include <TRestDetectorSignalEvent.h>
 
 #include "TRestEventProcess.h"
@@ -35,23 +34,22 @@
 class TRestDetectorSignalToHitsProcess : public TRestEventProcess {
    private:
     /// A pointer to the specific TRestDetectorHitsEvent output
-    TRestDetectorHitsEvent* fHitsEvent;      //!
+    TRestDetectorHitsEvent* fHitsEvent;  //!
 
     /// A pointer to the specific TRestDetectorHitsEvent input
     TRestDetectorSignalEvent* fSignalEvent;  //!
 
     /// A pointer to the detector readout definition accesible to TRestRun
     TRestDetectorReadout* fReadout;  //!
-    
+
     /// A pointer to the detector gas definition accessible to TRestRun
-    TRestDetectorGas* fGas;          //!
+    TRestDetectorGas* fGas;  //!
 
     void Initialize();
 
     void LoadDefaultConfig();
 
    protected:
-
     /// The electric field in standard REST units (V/mm). Only relevant if TRestDetectorGas is used.
     Double_t fElectricField = 100;
 

--- a/inc/TRestDetectorSignalViewerProcess.h
+++ b/inc/TRestDetectorSignalViewerProcess.h
@@ -25,7 +25,7 @@ class TRestDetectorSignalViewerProcess : public TRestEventProcess {
    private:
     TRestDetectorSignalEvent* fSignalEvent;  //!
 
-    vector<TObject*> fDrawingObjects;  //!
+    std::vector<TObject*> fDrawingObjects;  //!
     Double_t fDrawRefresh;             //!
 
     TVector2 fBaseLineRange;  //!
@@ -55,7 +55,7 @@ class TRestDetectorSignalViewerProcess : public TRestEventProcess {
     void PrintMetadata() {
         BeginPrintProcess();
 
-        cout << "Refresh value : " << fDrawRefresh << endl;
+        std::cout << "Refresh value : " << fDrawRefresh << endl;
 
         EndPrintProcess();
     }

--- a/inc/TRestDetectorSignalViewerProcess.h
+++ b/inc/TRestDetectorSignalViewerProcess.h
@@ -13,7 +13,6 @@
 #define RestCore_TRestDetectorSignalViewerProcess
 
 #include <TH1D.h>
-
 #include <TRestDetectorGas.h>
 #include <TRestDetectorHitsEvent.h>
 #include <TRestDetectorReadout.h>
@@ -26,7 +25,7 @@ class TRestDetectorSignalViewerProcess : public TRestEventProcess {
     TRestDetectorSignalEvent* fSignalEvent;  //!
 
     std::vector<TObject*> fDrawingObjects;  //!
-    Double_t fDrawRefresh;             //!
+    Double_t fDrawRefresh;                  //!
 
     TVector2 fBaseLineRange;  //!
 

--- a/inc/TRestDetectorSingleChannelAnalysisProcess.h
+++ b/inc/TRestDetectorSingleChannelAnalysisProcess.h
@@ -43,13 +43,13 @@ class TRestDetectorSingleChannelAnalysisProcess : public TRestEventProcess {
     TVector2 fThrIntegralCutRange;
     TVector2 fNGoodSignalsCutRange;
     TVector2 fSpecFitRange;
-    string fCalibSave;
+    std::string fCalibSave;
 
     // analysis result
-    map<int, TH1D*> fChannelThrIntegral;  //-> [channel id, sum]
-    map<int, double> fChannelFitMean;     // [MM id, fitted position]
-    map<int, double> fChannelGain;        // [MM id, channel gain]
-    map<int, double> fChannelGainError;   // [MM id, channel gain error]
+    std::map<int, TH1D*> fChannelThrIntegral;  //-> [channel id, sum]
+    std::map<int, double> fChannelFitMean;     // [MM id, fitted position]
+    std::map<int, double> fChannelGain;        // [MM id, channel gain]
+    std::map<int, double> fChannelGainError;   // [MM id, channel gain error]
 
    public:
     any GetInputEvent() { return fSignalEvent; }
@@ -57,20 +57,20 @@ class TRestDetectorSingleChannelAnalysisProcess : public TRestEventProcess {
 
     void FitChannelGain();
     // See comments on CXX
-    void SaveGainMetadata(string filename);
+    void SaveGainMetadata(std::string filename);
     void InitProcess();
     TRestEvent* ProcessEvent(TRestEvent* eventInput);
     void EndProcess();
     TH1D* GetChannelSpectrum(int id);
-    void PrintChannelSpectrums(string filename);
+    void PrintChannelSpectrums(std::string filename);
 
     void PrintMetadata() {
         BeginPrintProcess();
 
         metadata << "the mode is:" << endl;
-        metadata << (fApplyGainCorrection ? ">   " : "    ") << "Apply channel correction map for spectrum "
+        metadata << (fApplyGainCorrection ? ">   " : "    ") << "Apply channel correction std::map for spectrum "
                  << endl;
-        metadata << (fCreateGainMap ? ">   " : "    ") << "Create new correction map for each channel"
+        metadata << (fCreateGainMap ? ">   " : "    ") << "Create new correction std::map for each channel"
                  << endl;
         metadata << "output mapping file: " << fCalibSave << endl;
         metadata << "Energy cut for Threshold integral: " << any(fThrIntegralCutRange) << endl;

--- a/inc/TRestDetectorSingleChannelAnalysisProcess.h
+++ b/inc/TRestDetectorSingleChannelAnalysisProcess.h
@@ -68,8 +68,8 @@ class TRestDetectorSingleChannelAnalysisProcess : public TRestEventProcess {
         BeginPrintProcess();
 
         metadata << "the mode is:" << endl;
-        metadata << (fApplyGainCorrection ? ">   " : "    ") << "Apply channel correction std::map for spectrum "
-                 << endl;
+        metadata << (fApplyGainCorrection ? ">   " : "    ")
+                 << "Apply channel correction std::map for spectrum " << endl;
         metadata << (fCreateGainMap ? ">   " : "    ") << "Create new correction std::map for each channel"
                  << endl;
         metadata << "output mapping file: " << fCalibSave << endl;

--- a/inc/TRestDetectorTriggerAnalysisProcess.h
+++ b/inc/TRestDetectorTriggerAnalysisProcess.h
@@ -33,10 +33,10 @@ class TRestDetectorTriggerAnalysisProcess : public TRestEventProcess {
     /// A pointer to the specific TRestSignalEvent input
     TRestDetectorSignalEvent* fSignalEvent;  //!
 
-    /// A vector to temporary store the name of threshold observables
+    /// A std::vector to temporary store the name of threshold observables
     std::vector<std::string> fIntegralObservables;  //!
 
-    /// A vector to temporary the extracted threshold value from the corresponding observable
+    /// A std::vector to temporary the extracted threshold value from the corresponding observable
     std::vector<double> fThreshold;  //!
 
     void Initialize();
@@ -72,7 +72,7 @@ class TRestDetectorTriggerAnalysisProcess : public TRestEventProcess {
         EndPrintProcess();
     }
 
-    /// Returns a string with the process name
+    /// Returns a std::string with the process name
     TString GetProcessName() { return (TString) "triggerAnalysis"; }
 
     TRestDetectorTriggerAnalysisProcess();

--- a/macros/REST_Detector_CheckReadout.C
+++ b/macros/REST_Detector_CheckReadout.C
@@ -1,9 +1,9 @@
 #include <algorithm>
+#include <iostream>
 #include <vector>
+
 #include "TRestDetectorReadout.h"
 #include "TRestTask.h"
-
-#include <iostream>
 using namespace std;
 
 TGraph* GetHittedStripMap(TRestDetectorReadoutPlane* p, Int_t mask[4], Double_t region[4], Int_t N,

--- a/macros/REST_Detector_ViewReadout.C
+++ b/macros/REST_Detector_ViewReadout.C
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <vector>
+
 #include "TRestBrowser.h"
 #include "TRestDetectorReadout.h"
 #include "TRestTask.h"

--- a/src/TRestDetector.cxx
+++ b/src/TRestDetector.cxx
@@ -74,4 +74,8 @@ void TRestDetector::UpdateMetadataMembers() {
     }
 }
 
+
+using namespace std;
+
 ClassImp(TRestDetector);
+

--- a/src/TRestDetector.cxx
+++ b/src/TRestDetector.cxx
@@ -74,8 +74,6 @@ void TRestDetector::UpdateMetadataMembers() {
     }
 }
 
-
 using namespace std;
 
 ClassImp(TRestDetector);
-

--- a/src/TRestDetectorDaqChannelSwitchingProcess.cxx
+++ b/src/TRestDetectorDaqChannelSwitchingProcess.cxx
@@ -14,10 +14,10 @@
 ///
 ///_______________________________________________________________________________
 
+#include "TRestDetectorDaqChannelSwitchingProcess.h"
+
 #include <TLegend.h>
 #include <TPaveText.h>
-
-#include "TRestDetectorDaqChannelSwitchingProcess.h"
 using namespace std;
 
 ClassImp(TRestDetectorDaqChannelSwitchingProcess)

--- a/src/TRestDetectorDriftVolume.cxx
+++ b/src/TRestDetectorDriftVolume.cxx
@@ -1,15 +1,11 @@
 #include "TRestDetectorDriftVolume.h"
 using namespace REST_Units;
 
-
 using namespace std;
 
 ClassImp(TRestDetectorDriftVolume);
 
-
-    TRestDetectorDriftVolume::TRestDetectorDriftVolume() {
-    Initialize();
-}
+TRestDetectorDriftVolume::TRestDetectorDriftVolume() { Initialize(); }
 TRestDetectorDriftVolume::TRestDetectorDriftVolume(const char* cfgFileName, string name)
     : TRestMetadata(cfgFileName) {
     LoadConfigFromFile(cfgFileName, name);

--- a/src/TRestDetectorDriftVolume.cxx
+++ b/src/TRestDetectorDriftVolume.cxx
@@ -1,7 +1,11 @@
 #include "TRestDetectorDriftVolume.h"
 using namespace REST_Units;
 
-ClassImp(TRestDetectorDriftVolume)
+
+using namespace std;
+
+ClassImp(TRestDetectorDriftVolume);
+
 
     TRestDetectorDriftVolume::TRestDetectorDriftVolume() {
     Initialize();

--- a/src/TRestDetectorGainMap.cxx
+++ b/src/TRestDetectorGainMap.cxx
@@ -7,7 +7,11 @@
 #include "TView.h"
 
 #include "TRestDetectorReadout.h"
+
+using namespace std;
+
 ClassImp(TRestDetectorGainMap);
+
 
 void TRestDetectorGainMap::InitFromConfigFile() {
     // read config from rml section

--- a/src/TRestDetectorGainMap.cxx
+++ b/src/TRestDetectorGainMap.cxx
@@ -3,15 +3,13 @@
 #include "TGraph2D.h"
 #include "TLegend.h"
 #include "TRandom.h"
+#include "TRestDetectorReadout.h"
 #include "TStyle.h"
 #include "TView.h"
-
-#include "TRestDetectorReadout.h"
 
 using namespace std;
 
 ClassImp(TRestDetectorGainMap);
-
 
 void TRestDetectorGainMap::InitFromConfigFile() {
     // read config from rml section

--- a/src/TRestDetectorGarfieldDriftProcess.cxx
+++ b/src/TRestDetectorGarfieldDriftProcess.cxx
@@ -14,10 +14,10 @@
 ///             march 2017:   Damien Neyret
 ///_______________________________________________________________________________
 
+#include "TRestDetectorGarfieldDriftProcess.h"
+
 #include <TGeoBBox.h>
 #include <TRandom3.h>
-
-#include "TRestDetectorGarfieldDriftProcess.h"
 
 #if defined USE_Garfield
 #include "ComponentConstant.hh"

--- a/src/TRestDetectorGas.cxx
+++ b/src/TRestDetectorGas.cxx
@@ -1188,7 +1188,8 @@ void TRestDetectorGas::PrintGasInfo() {
     metadata << "Temperature : " << fTemperatureInK << " K" << endl;
     metadata << "Electric Field : " << fElectricField * units("V/cm") << " V/cm " << endl;
     metadata << "W-value : " << fW << " eV" << endl;
-    metadata << "Drift velocity : " << GetDriftVelocity(fElectricField * units("V/cm")) / units("cm/us") << " mm/us " << endl;
+    metadata << "Drift velocity : " << GetDriftVelocity(fElectricField * units("V/cm")) / units("cm/us")
+             << " mm/us " << endl;
     metadata << "Max. Electron energy : " << fMaxElectronEnergy << " eV" << endl;
     metadata << "Field grid nodes : " << fEnodes << endl;
     metadata << "Efield range : ( " << fEmin << " , " << fEmax << " ) V/cm " << endl;

--- a/src/TRestDetectorHitsToSignalProcess.cxx
+++ b/src/TRestDetectorHitsToSignalProcess.cxx
@@ -279,4 +279,3 @@ TRestEvent* TRestDetectorHitsToSignalProcess::ProcessEvent(TRestEvent* evInput) 
 
     return fSignalEvent;
 }
-

--- a/src/TRestDetectorReadoutModule.cxx
+++ b/src/TRestDetectorReadoutModule.cxx
@@ -43,6 +43,7 @@
 ///
 
 #include "TRestDetectorReadoutModule.h"
+
 #include "unistd.h"
 using namespace std;
 

--- a/src/TRestDetectorSetup.cxx
+++ b/src/TRestDetectorSetup.cxx
@@ -15,6 +15,7 @@
 ///_______________________________________________________________________________
 
 #include "TRestDetectorSetup.h"
+
 #include "TRestManager.h"
 #include "TRestRun.h"
 using namespace std;

--- a/src/TRestDetectorSignalEvent.cxx
+++ b/src/TRestDetectorSignalEvent.cxx
@@ -19,9 +19,9 @@
 ///		  Javier Gracia
 ///_______________________________________________________________________________
 
-#include <TMath.h>
-
 #include "TRestDetectorSignalEvent.h"
+
+#include <TMath.h>
 using namespace std;
 
 ClassImp(TRestDetectorSignalEvent)

--- a/src/TRestDetectorSignalToHitsProcess.cxx
+++ b/src/TRestDetectorSignalToHitsProcess.cxx
@@ -356,4 +356,3 @@ TRestEvent* TRestDetectorSignalToHitsProcess::ProcessEvent(TRestEvent* evInput) 
 
     return fHitsEvent;
 }
-

--- a/src/TRestDetectorSignalViewerProcess.cxx
+++ b/src/TRestDetectorSignalViewerProcess.cxx
@@ -14,10 +14,10 @@
 ///
 ///_______________________________________________________________________________
 
+#include "TRestDetectorSignalViewerProcess.h"
+
 #include <TLegend.h>
 #include <TPaveText.h>
-
-#include "TRestDetectorSignalViewerProcess.h"
 using namespace std;
 
 int rawCounter3 = 0;

--- a/src/TRestDetectorSingleChannelAnalysisProcess.cxx
+++ b/src/TRestDetectorSingleChannelAnalysisProcess.cxx
@@ -268,7 +268,6 @@ void TRestDetectorSingleChannelAnalysisProcess::SaveGainMetadata(string filename
     delete r;
 }
 
-
 TH1D* TRestDetectorSingleChannelAnalysisProcess::GetChannelSpectrum(int id) {
     if (fChannelThrIntegral.count(id) != 0) return fChannelThrIntegral[id];
     return NULL;

--- a/src/TRestDetectorTriggerAnalysisProcess.cxx
+++ b/src/TRestDetectorTriggerAnalysisProcess.cxx
@@ -215,4 +215,3 @@ TRestEvent* TRestDetectorTriggerAnalysisProcess::ProcessEvent(TRestEvent* evInpu
 
     return fSignalEvent;
 }
-


### PR DESCRIPTION
![Large](https://badgen.net/badge/PR%20Size/Large/red) ![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![118](https://badgen.net/badge/Size/118/orange) [![](https://gitlab.cern.ch/rest-for-physics/detectorlib/badges/lobis-remove-namespace-std-from-headers/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/detectorlib/-/commits/lobis-remove-namespace-std-from-headers)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Needed for https://github.com/rest-for-physics/framework/pull/168. Read PR for additional info.