### PR TITLE
Fixing bug on inheritance of DrawEvent from base class

### DIFF
--- a/inc/TRestDetectorHitsEvent.h
+++ b/inc/TRestDetectorHitsEvent.h
@@ -171,7 +171,7 @@ class TRestDetectorHitsEvent : public TRestEvent {
     Double_t GetClosestHitInsideDistanceToPrismBottom(TVector3 x0, TVector3 x1, Double_t sizeX,
                                                       Double_t sizeY, Double_t theta);
 
-    TPad* DrawEvent(TString option = "");
+    TPad* DrawEvent(const TString& option = "");
     void DrawHistograms(Int_t& column, Double_t pitch = 3, TString histOption = "");
     void DrawGraphs(Int_t& column);
 

--- a/inc/TRestDetectorSignalEvent.h
+++ b/inc/TRestDetectorSignalEvent.h
@@ -92,7 +92,7 @@ class TRestDetectorSignalEvent : public TRestEvent {
     void Initialize();
     void PrintEvent();
 
-    TPad* DrawEvent(TString option = "");
+    TPad* DrawEvent(const TString& option = "");
 
     // Construtor
     TRestDetectorSignalEvent();

--- a/src/TRestDetectorHitsEvent.cxx
+++ b/src/TRestDetectorHitsEvent.cxx
@@ -604,7 +604,7 @@ Double_t TRestDetectorHitsEvent::GetClosestHitInsideDistanceToPrismBottom(TVecto
 ///
 /// \return A pointer to the TPad where the event was drawn is returned.
 ///
-TPad* TRestDetectorHitsEvent::DrawEvent(TString option) {
+TPad* TRestDetectorHitsEvent::DrawEvent(const TString& option) {
     vector<TString> optList = Vector_cast<string, TString>(TRestTools::GetOptions((string)option));
 
     SetBoundaries();

--- a/src/TRestDetectorSignalEvent.cxx
+++ b/src/TRestDetectorSignalEvent.cxx
@@ -186,7 +186,7 @@ Double_t TRestDetectorSignalEvent::GetMaxTime() {
 }
 
 // Draw current event in a Tpad
-TPad* TRestDetectorSignalEvent::DrawEvent(TString option) {
+TPad* TRestDetectorSignalEvent::DrawEvent(const TString& option) {
     if (fPad != NULL) {
         delete fPad;
         fPad = NULL;


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![4](https://badgen.net/badge/Size/4/orange) [![](https://gitlab.cern.ch/rest-for-physics/detectorlib/badges/DrawEventFix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/detectorlib/-/commits/DrawEventFix)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

After new changes in the code, it seems that `DrawEvent` is not working for some inherited classes from `TRestEvent`

This PR fix this bug by replacing:
```
- TPad* DrawEvent(TString option = "");
+ TPad* DrawEvent(const TString& option = "");
```