### PR TITLE
Renaming endl to RESTendl and other loggers functions

### DIFF
--- a/inc/TRestDetectorAvalancheProcess.h
+++ b/inc/TRestDetectorAvalancheProcess.h
@@ -51,9 +51,9 @@ class TRestDetectorAvalancheProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << " reference energy (Eref): " << fEnergyRef << endl;
-        metadata << " resolution at Eref : " << fResolutionAtEref << endl;
-        metadata << " detector gain : " << fDetectorGain << endl;
+        RESTMetadata << " reference energy (Eref): " << fEnergyRef << RESTendl;
+        RESTMetadata << " resolution at Eref : " << fResolutionAtEref << RESTendl;
+        RESTMetadata << " detector gain : " << fDetectorGain << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestDetectorDaqChannelSwitchingProcess.h
+++ b/inc/TRestDetectorDaqChannelSwitchingProcess.h
@@ -43,13 +43,13 @@ class TRestDetectorDaqChannelSwitchingProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << "module's daq channel re-definition: " << endl;
+        RESTMetadata << "module's daq channel re-definition: " << RESTendl;
         auto iter = fFirstDaqChannelDef.begin();
         while (iter != fFirstDaqChannelDef.end()) {
-            metadata << "module id: " << iter->first << " first daq channel: " << iter->second << endl;
+            RESTMetadata << "module id: " << iter->first << " first daq channel: " << iter->second << RESTendl;
             iter++;
         }
-        metadata << endl;
+        RESTMetadata << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestDetectorElectronDiffusionProcess.h
+++ b/inc/TRestDetectorElectronDiffusionProcess.h
@@ -64,16 +64,16 @@ class TRestDetectorElectronDiffusionProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << " eField : " << fElectricField * units("V/cm") << " V/cm" << endl;
-        metadata << " attachment coeficient : " << fAttachment << " V/cm" << endl;
-        metadata << " gas pressure : " << fGasPressure << " atm" << endl;
-        metadata << " longitudinal diffusion coefficient : " << fLonglDiffCoeff << " cm^1/2" << endl;
-        metadata << " transversal diffusion coefficient : " << fTransDiffCoeff << " cm^1/2" << endl;
-        metadata << " W value : " << fWvalue << " eV" << endl;
+        RESTMetadata << " eField : " << fElectricField * units("V/cm") << " V/cm" << RESTendl;
+        RESTMetadata << " attachment coeficient : " << fAttachment << " V/cm" << RESTendl;
+        RESTMetadata << " gas pressure : " << fGasPressure << " atm" << RESTendl;
+        RESTMetadata << " longitudinal diffusion coefficient : " << fLonglDiffCoeff << " cm^1/2" << RESTendl;
+        RESTMetadata << " transversal diffusion coefficient : " << fTransDiffCoeff << " cm^1/2" << RESTendl;
+        RESTMetadata << " W value : " << fWvalue << " eV" << RESTendl;
 
-        metadata << " Maximum number of hits : " << fMaxHits << endl;
+        RESTMetadata << " Maximum number of hits : " << fMaxHits << RESTendl;
 
-        metadata << " seed : " << fSeed << endl;
+        RESTMetadata << " seed : " << fSeed << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestDetectorGarfieldDriftProcess.h
+++ b/inc/TRestDetectorGarfieldDriftProcess.h
@@ -90,10 +90,10 @@ class TRestDetectorGarfieldDriftProcess : public TRestEventProcess {
 
         //             std::cout << "Electric field : " << fElectricField << " V/cm"
         //             << endl;
-        metadata << "Drift electrode potential : " << fDriftPotential << " V" << endl;
-        metadata << "Gas pressure : " << fGasPressure << " atm" << endl;
-        metadata << "Electron reduction factor : " << fPEReduction << endl;
-        metadata << "Drift stop distance : " << fStopDistance << " mm" << endl;
+        RESTMetadata << "Drift electrode potential : " << fDriftPotential << " V" << RESTendl;
+        RESTMetadata << "Gas pressure : " << fGasPressure << " atm" << RESTendl;
+        RESTMetadata << "Electron reduction factor : " << fPEReduction << RESTendl;
+        RESTMetadata << "Drift stop distance : " << fStopDistance << " mm" << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestDetectorGas.h
+++ b/inc/TRestDetectorGas.h
@@ -164,7 +164,7 @@ class TRestDetectorGas : public TRestDetectorDriftVolume {
     inline TString GetGasComponentName(Int_t n) {
         if (n >= GetNofGases()) {
             std::cout << "REST WARNING. Gas name component n=" << n << " requested. But only "
-                      << GetNofGases() << " component(s) in the mixture." << endl;
+                      << GetNofGases() << " component(s) in the mixture." << std::endl;
             return "";
         }
         return fGasComponentName[n];
@@ -174,9 +174,9 @@ class TRestDetectorGas : public TRestDetectorDriftVolume {
 
     Double_t GetDriftVelocity() const override {
         if (fElectricField == 0) {
-            warning << "TRestDetectorGas::GetDriftVelocity. Warning fElectricField is zero!" << endl;
-            warning << " - Use: TRestDetectorGas::SetElectricField( field[V/mm] ) to set the field value"
-                    << endl;
+            RESTWarning << "TRestDetectorGas::GetDriftVelocity. Warning fElectricField is zero!" << RESTendl;
+            RESTWarning << " - Use: TRestDetectorGas::SetElectricField( field[V/mm] ) to set the field value"
+                    << RESTendl;
         }
         return GetDriftVelocity(fElectricField * units("V/cm")) / units("cm/us");
     }  // in standard unit mm/us
@@ -184,9 +184,9 @@ class TRestDetectorGas : public TRestDetectorDriftVolume {
     /// Returns the longitudinal diffusion in (cm)^1/2
     Double_t GetLongitudinalDiffusion() const override {
         if (fElectricField == 0) {
-            warning << "TRestDetectorGas::GetLongitudinalDiffusion. Warning fElectricField is zero!" << endl;
-            warning << " - Use: TRestDetectorGas::SetElectricField( field[V/mm] ) to set the field value"
-                    << endl;
+            RESTWarning << "TRestDetectorGas::GetLongitudinalDiffusion. Warning fElectricField is zero!" << RESTendl;
+            RESTWarning << " - Use: TRestDetectorGas::SetElectricField( field[V/mm] ) to set the field value"
+                    << RESTendl;
         }
         return GetLongitudinalDiffusion(fElectricField * units("V/cm"));
     }
@@ -194,27 +194,27 @@ class TRestDetectorGas : public TRestDetectorDriftVolume {
     /// Returns the transversal diffusion in (cm)^1/2
     Double_t GetTransversalDiffusion() const override {
         if (fElectricField == 0) {
-            warning << "TRestDetectorGas::GetTransversalDiffusion. Warning fElectricField is zero!" << endl;
-            warning << " - Use: TRestDetectorGas::SetElectricField( field[V/mm] ) to set the field value"
-                    << endl;
+            RESTWarning << "TRestDetectorGas::GetTransversalDiffusion. Warning fElectricField is zero!" << RESTendl;
+            RESTWarning << " - Use: TRestDetectorGas::SetElectricField( field[V/mm] ) to set the field value"
+                    << RESTendl;
         }
         return GetTransversalDiffusion(fElectricField * units("V/cm"));
     }
 
     Double_t GetTownsendCoefficient() const override {
         if (fElectricField == 0) {
-            warning << "TRestDetectorGas::GetTownsendCoefficient. Warning fElectricField is zero!" << endl;
-            warning << " - Use: TRestDetectorGas::SetElectricField( field[V/mm] ) to set the field value"
-                    << endl;
+            RESTWarning << "TRestDetectorGas::GetTownsendCoefficient. Warning fElectricField is zero!" << RESTendl;
+            RESTWarning << " - Use: TRestDetectorGas::SetElectricField( field[V/mm] ) to set the field value"
+                    << RESTendl;
         }
         return GetTownsendCoefficient(fElectricField * units("V/cm"));
     }
 
     Double_t GetAttachmentCoefficient() const override {
         if (fElectricField == 0) {
-            warning << "TRestDetectorGas::GetAttachmentCoefficient. Warning fElectricField is zero!" << endl;
-            warning << " - Use: TRestDetectorGas::SetElectricField( field[V/mm] ) to set the field value"
-                    << endl;
+            RESTWarning << "TRestDetectorGas::GetAttachmentCoefficient. Warning fElectricField is zero!" << RESTendl;
+            RESTWarning << " - Use: TRestDetectorGas::SetElectricField( field[V/mm] ) to set the field value"
+                    << RESTendl;
         }
         return GetAttachmentCoefficient(fElectricField * units("V/cm"));
     }
@@ -225,7 +225,7 @@ class TRestDetectorGas : public TRestDetectorDriftVolume {
     inline Double_t GetGasComponentFraction(Int_t n) {
         if (n >= GetNofGases()) {
             std::cout << "REST WARNING. Gas fraction for component n=" << n << " requested. But only "
-                      << GetNofGases() << " component(s) in the mixture." << endl;
+                      << GetNofGases() << " component(s) in the mixture." << std::endl;
             return 0.;
         }
 
@@ -251,7 +251,7 @@ class TRestDetectorGas : public TRestDetectorDriftVolume {
     void PlotTransversalDiffusion(Double_t eMin, Double_t eMax, Int_t nSteps);
     void PlotTownsendCoefficient(Double_t eMin, Double_t eMax, Int_t nSteps);
     void PrintGasInfo();
-    inline void PrintGasFileContent() { std::cout << fGasFileContent << endl; };
+    inline void PrintGasFileContent() { std::cout << fGasFileContent << std::endl; };
 
     /// Prints the metadata information from the gas
     void PrintMetadata() override { PrintGasInfo(); }

--- a/inc/TRestDetectorHitsAnalysisProcess.h
+++ b/inc/TRestDetectorHitsAnalysisProcess.h
@@ -70,18 +70,18 @@ class TRestDetectorHitsAnalysisProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        if (fCylinderFiducial) metadata << "Cylinder fiducial active" << endl;
-        if (fPrismFiducial) metadata << "Prism fiducial active" << endl;
+        if (fCylinderFiducial) RESTMetadata << "Cylinder fiducial active" << RESTendl;
+        if (fPrismFiducial) RESTMetadata << "Prism fiducial active" << RESTendl;
 
-        metadata << " -------------------" << endl;
-        metadata << " Fiducial parameters" << endl;
-        metadata << " -------------------" << endl;
-        metadata << " x0 : (" << fFid_x0.X() << " , " << fFid_x0.Y() << " , " << fFid_x0.Z() << ")" << endl;
-        metadata << " x1 : (" << fFid_x1.X() << " , " << fFid_x1.Y() << " , " << fFid_x1.Z() << ")" << endl;
-        metadata << " R : " << fFid_R << endl;
-        metadata << " sX : " << fFid_sX << endl;
-        metadata << " sY : " << fFid_sY << endl;
-        metadata << " -------------------" << endl;
+        RESTMetadata << " -------------------" << RESTendl;
+        RESTMetadata << " Fiducial parameters" << RESTendl;
+        RESTMetadata << " -------------------" << RESTendl;
+        RESTMetadata << " x0 : (" << fFid_x0.X() << " , " << fFid_x0.Y() << " , " << fFid_x0.Z() << ")" << RESTendl;
+        RESTMetadata << " x1 : (" << fFid_x1.X() << " , " << fFid_x1.Y() << " , " << fFid_x1.Z() << ")" << RESTendl;
+        RESTMetadata << " R : " << fFid_R << RESTendl;
+        RESTMetadata << " sX : " << fFid_sX << RESTendl;
+        RESTMetadata << " sY : " << fFid_sY << RESTendl;
+        RESTMetadata << " -------------------" << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestDetectorHitsNormalizationProcess.h
+++ b/inc/TRestDetectorHitsNormalizationProcess.h
@@ -47,7 +47,7 @@ class TRestDetectorHitsNormalizationProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << " Renormalization factor : " << fFactor << endl;
+        RESTMetadata << " Renormalization factor : " << fFactor << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestDetectorHitsReductionProcess.h
+++ b/inc/TRestDetectorHitsReductionProcess.h
@@ -44,10 +44,10 @@ class TRestDetectorHitsReductionProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << " Starting distance : " << fStartingDistance << endl;
-        metadata << " Minimum distance : " << fMinimumDistance << endl;
-        metadata << " Distance step factor : " << fDistanceFactor << endl;
-        metadata << " Maximum number of nodes : " << fMaxNodes << endl;
+        RESTMetadata << " Starting distance : " << fStartingDistance << RESTendl;
+        RESTMetadata << " Minimum distance : " << fMinimumDistance << RESTendl;
+        RESTMetadata << " Distance step factor : " << fDistanceFactor << RESTendl;
+        RESTMetadata << " Maximum number of nodes : " << fMaxNodes << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestDetectorHitsRotateAndTranslateProcess.h
+++ b/inc/TRestDetectorHitsRotateAndTranslateProcess.h
@@ -54,12 +54,12 @@ class TRestDetectorHitsRotateAndTranslateProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << " delta x : " << fDeltaX << endl;
-        metadata << " delta y : " << fDeltaY << endl;
-        metadata << " delta z : " << fDeltaZ << endl;
-        metadata << " alpha : " << fAlpha << endl;
-        metadata << " beta : " << fBeta << endl;
-        metadata << " gamma : " << fGamma << endl;
+        RESTMetadata << " delta x : " << fDeltaX << RESTendl;
+        RESTMetadata << " delta y : " << fDeltaY << RESTendl;
+        RESTMetadata << " delta z : " << fDeltaZ << RESTendl;
+        RESTMetadata << " alpha : " << fAlpha << RESTendl;
+        RESTMetadata << " beta : " << fBeta << RESTendl;
+        RESTMetadata << " gamma : " << fGamma << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestDetectorHitsShuffleProcess.h
+++ b/inc/TRestDetectorHitsShuffleProcess.h
@@ -46,7 +46,7 @@ class TRestDetectorHitsShuffleProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << " Iterations : " << fIterations << endl;
+        RESTMetadata << " Iterations : " << fIterations << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestDetectorHitsSmearingProcess.h
+++ b/inc/TRestDetectorHitsSmearingProcess.h
@@ -54,8 +54,8 @@ class TRestDetectorHitsSmearingProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << " reference energy (ERef): " << fEnergyRef << endl;
-        metadata << " resolution at ERef : " << fResolutionAtERef << endl;
+        RESTMetadata << " reference energy (ERef): " << fEnergyRef << RESTendl;
+        RESTMetadata << " resolution at ERef : " << fResolutionAtERef << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestDetectorHitsToSignalProcess.h
+++ b/inc/TRestDetectorHitsToSignalProcess.h
@@ -73,10 +73,10 @@ class TRestDetectorHitsToSignalProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << "Sampling : " << fSampling << " us" << endl;
-        metadata << "Electric field : " << fElectricField * units("V/cm") << " V/cm" << endl;
-        metadata << "Gas pressure : " << fGasPressure << " atm" << endl;
-        metadata << "Drift velocity : " << fDriftVelocity << " mm/us" << endl;
+        RESTMetadata << "Sampling : " << fSampling << " us" << RESTendl;
+        RESTMetadata << "Electric field : " << fElectricField * units("V/cm") << " V/cm" << RESTendl;
+        RESTMetadata << "Gas pressure : " << fGasPressure << " atm" << RESTendl;
+        RESTMetadata << "Drift velocity : " << fDriftVelocity << " mm/us" << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestDetectorPositionMappingProcess.h
+++ b/inc/TRestDetectorPositionMappingProcess.h
@@ -63,15 +63,15 @@ class TRestDetectorPositionMappingProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << "the mode is:" << endl;
-        metadata << (fApplyGainCorrection ? ">   " : "    ")
-                 << "Apply position correction std::map for spectrum " << endl;
-        metadata << (fCreateGainMap ? ">   " : "    ") << "Create new correction std::map for each position"
-                 << endl;
-        metadata << "output mapping file: " << fMappingSave << endl;
-        metadata << "Energy cut for Threshold integral: " << any(fEnergyCutRange) << endl;
-        metadata << "Energy cut for NGoodSignals: " << any(fNHitsCutRange) << endl;
-        metadata << "Binning: " << fNBinsX << ", " << fNBinsY << ", " << fNBinsZ << endl;
+        RESTMetadata << "the mode is:" << RESTendl;
+        RESTMetadata << (fApplyGainCorrection ? ">   " : "    ")
+                 << "Apply position correction std::map for spectrum " << RESTendl;
+        RESTMetadata << (fCreateGainMap ? ">   " : "    ") << "Create new correction std::map for each position"
+                 << RESTendl;
+        RESTMetadata << "output mapping file: " << fMappingSave << RESTendl;
+        RESTMetadata << "Energy cut for Threshold integral: " << any(fEnergyCutRange) << RESTendl;
+        RESTMetadata << "Energy cut for NGoodSignals: " << any(fNHitsCutRange) << RESTendl;
+        RESTMetadata << "Binning: " << fNBinsX << ", " << fNBinsY << ", " << fNBinsZ << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestDetectorSignalChannelActivityProcess.h
+++ b/inc/TRestDetectorSignalChannelActivityProcess.h
@@ -113,16 +113,16 @@ class TRestDetectorSignalChannelActivityProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << "Low signal threshold activity : " << fLowThreshold << endl;
-        metadata << "High signal threshold activity : " << fHighThreshold << endl;
+        RESTMetadata << "Low signal threshold activity : " << fLowThreshold << RESTendl;
+        RESTMetadata << "High signal threshold activity : " << fHighThreshold << RESTendl;
 
-        metadata << "Number of daq histogram channels : " << fDaqHistogramChannels << endl;
-        metadata << "Start daq channel : " << fDaqStartChannel << endl;
-        metadata << "End daq channel : " << fDaqEndChannel << endl;
+        RESTMetadata << "Number of daq histogram channels : " << fDaqHistogramChannels << RESTendl;
+        RESTMetadata << "Start daq channel : " << fDaqStartChannel << RESTendl;
+        RESTMetadata << "End daq channel : " << fDaqEndChannel << RESTendl;
 
-        metadata << "Number of readout histogram channels : " << fReadoutHistogramChannels << endl;
-        metadata << "Start readout channel : " << fReadoutStartChannel << endl;
-        metadata << "End readout channel : " << fReadoutEndChannel << endl;
+        RESTMetadata << "Number of readout histogram channels : " << fReadoutHistogramChannels << RESTendl;
+        RESTMetadata << "Start readout channel : " << fReadoutStartChannel << RESTendl;
+        RESTMetadata << "End readout channel : " << fReadoutEndChannel << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestDetectorSignalToHitsProcess.h
+++ b/inc/TRestDetectorSignalToHitsProcess.h
@@ -81,13 +81,13 @@ class TRestDetectorSignalToHitsProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << "Electric field : " << fElectricField * units("V/cm") << " V/cm" << endl;
-        metadata << "Gas pressure : " << fGasPressure << " atm" << endl;
-        metadata << "Drift velocity : " << fDriftVelocity << " mm/us" << endl;
-        metadata << "Signal to hits method : " << fMethod << endl;
+        RESTMetadata << "Electric field : " << fElectricField * units("V/cm") << " V/cm" << RESTendl;
+        RESTMetadata << "Gas pressure : " << fGasPressure << " atm" << RESTendl;
+        RESTMetadata << "Drift velocity : " << fDriftVelocity << " mm/us" << RESTendl;
+        RESTMetadata << "Signal to hits method : " << fMethod << RESTendl;
         if (fMethod == "intwindow") {
-            metadata << "Threshold : " << fThreshold << " ADC" << endl;
-            metadata << "Integral window : " << fIntWindow << " us" << endl;
+            RESTMetadata << "Threshold : " << fThreshold << " ADC" << RESTendl;
+            RESTMetadata << "Integral window : " << fIntWindow << " us" << RESTendl;
         }
 
         EndPrintProcess();

--- a/inc/TRestDetectorSignalViewerProcess.h
+++ b/inc/TRestDetectorSignalViewerProcess.h
@@ -54,7 +54,7 @@ class TRestDetectorSignalViewerProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        std::cout << "Refresh value : " << fDrawRefresh << endl;
+        std::cout << "Refresh value : " << fDrawRefresh << std::endl;
 
         EndPrintProcess();
     }

--- a/inc/TRestDetectorSingleChannelAnalysisProcess.h
+++ b/inc/TRestDetectorSingleChannelAnalysisProcess.h
@@ -64,15 +64,15 @@ class TRestDetectorSingleChannelAnalysisProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << "the mode is:" << endl;
-        metadata << (fApplyGainCorrection ? ">   " : "    ")
-                 << "Apply channel correction std::map for spectrum " << endl;
-        metadata << (fCreateGainMap ? ">   " : "    ") << "Create new correction std::map for each channel"
-                 << endl;
-        metadata << "output mapping file: " << fCalibSave << endl;
-        metadata << "Energy cut for Threshold integral: " << any(fThrIntegralCutRange) << endl;
-        metadata << "Energy cut for NGoodSignals: " << any(fNGoodSignalsCutRange) << endl;
-        metadata << "Fit range for the spectra: " << any(fSpecFitRange) << endl;
+        RESTMetadata << "the mode is:" << RESTendl;
+        RESTMetadata << (fApplyGainCorrection ? ">   " : "    ")
+                 << "Apply channel correction std::map for spectrum " << RESTendl;
+        RESTMetadata << (fCreateGainMap ? ">   " : "    ") << "Create new correction std::map for each channel"
+                 << RESTendl;
+        RESTMetadata << "output mapping file: " << fCalibSave << RESTendl;
+        RESTMetadata << "Energy cut for Threshold integral: " << any(fThrIntegralCutRange) << RESTendl;
+        RESTMetadata << "Energy cut for NGoodSignals: " << any(fNGoodSignalsCutRange) << RESTendl;
+        RESTMetadata << "Fit range for the spectra: " << any(fSpecFitRange) << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestDetectorTriggerAnalysisProcess.h
+++ b/inc/TRestDetectorTriggerAnalysisProcess.h
@@ -66,8 +66,8 @@ class TRestDetectorTriggerAnalysisProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << "Sampling : " << fSampling << " us" << endl;
-        metadata << "ADC length : " << fADCLength << endl;
+        RESTMetadata << "Sampling : " << fSampling << " us" << RESTendl;
+        RESTMetadata << "ADC length : " << fADCLength << RESTendl;
 
         EndPrintProcess();
     }

--- a/macros/REST_Detector_HitCentering.C
+++ b/macros/REST_Detector_HitCentering.C
@@ -33,7 +33,7 @@
 
 Int_t REST_Detector_HitCentering(TString rootFileName, TString histoName, int startVal = -30, int endVal = 30,
                                  int bins = 120, int n1 = 0, int n2 = 60000, double invalidVal = -0.125) {
-    TRestStringOutput RESTcout;
+    TRestStringOutput RESTLog;
 
     std::vector<string> inputFilesNew = TRestTools::GetFilesMatchingPattern((string)rootFileName);
 
@@ -41,7 +41,7 @@ Int_t REST_Detector_HitCentering(TString rootFileName, TString histoName, int st
     TH1D* hY = new TH1D(histoName + "Y", histoName + "Y", bins, startVal, endVal);
 
     if (inputFilesNew.size() == 0) {
-        RESTcout << "Files not found!" << RESTendl;
+        RESTLog << "Files not found!" << RESTendl;
         return -1;
     }
 
@@ -81,7 +81,7 @@ Int_t REST_Detector_HitCentering(TString rootFileName, TString histoName, int st
     hY->Write(histoName + "Y");
     f->Close();
 
-    RESTcout << "Written histograms " << histoName << "X/Y into " << rootFileName << RESTendl;
+    RESTLog << "Written histograms " << histoName << "X/Y into " << rootFileName << RESTendl;
 
     return 0;
 };

--- a/macros/REST_Detector_HitCentering.C
+++ b/macros/REST_Detector_HitCentering.C
@@ -33,7 +33,7 @@
 
 Int_t REST_Detector_HitCentering(TString rootFileName, TString histoName, int startVal = -30, int endVal = 30,
                                  int bins = 120, int n1 = 0, int n2 = 60000, double invalidVal = -0.125) {
-    TRestStringOutput cout;
+    TRestStringOutput RESTcout;
 
     std::vector<string> inputFilesNew = TRestTools::GetFilesMatchingPattern((string)rootFileName);
 
@@ -41,7 +41,7 @@ Int_t REST_Detector_HitCentering(TString rootFileName, TString histoName, int st
     TH1D* hY = new TH1D(histoName + "Y", histoName + "Y", bins, startVal, endVal);
 
     if (inputFilesNew.size() == 0) {
-        cout << "Files not found!" << endl;
+        RESTcout << "Files not found!" << RESTendl;
         return -1;
     }
 
@@ -81,7 +81,7 @@ Int_t REST_Detector_HitCentering(TString rootFileName, TString histoName, int st
     hY->Write(histoName + "Y");
     f->Close();
 
-    cout << "Written histograms " << histoName << "X/Y into " << rootFileName << endl;
+    RESTcout << "Written histograms " << histoName << "X/Y into " << rootFileName << RESTendl;
 
     return 0;
 };

--- a/src/TRestDetector.cxx
+++ b/src/TRestDetector.cxx
@@ -65,9 +65,9 @@ void TRestDetector::PrintMetadata() {
     for (int i = 0; i < cl.GetNumberOfDataMembers(); i++) {
         if (cl.GetDataMember(i).name == "fgIsA") continue;
         if (cl.GetDataMember(i).ToString() != "-1")
-            metadata << cl.GetDataMember(i).name << ": " << cl.GetDataMember(i).ToString() << endl;
+            RESTMetadata << cl.GetDataMember(i).name << ": " << cl.GetDataMember(i).ToString() << RESTendl;
     }
-    metadata << "---------------------------------------" << endl;
+    RESTMetadata << "---------------------------------------" << RESTendl;
 }
 
 void TRestDetector::UpdateMetadataMembers() {

--- a/src/TRestDetectorDriftVolume.cxx
+++ b/src/TRestDetectorDriftVolume.cxx
@@ -50,13 +50,13 @@ void TRestDetectorDriftVolume::InitFromConfigFile() {
 void TRestDetectorDriftVolume::PrintMetadata() {
     TRestMetadata::PrintMetadata();
 
-    metadata << "Drift Volume Material : " << fMaterial << ", W-value : " << fW << " eV" << endl;
-    metadata << "Electric Field : " << fElectricField * V / cm << " V/cm " << endl;
-    metadata << "Drift Speed : " << fDriftVelocity * mm / us << " mm/us" << endl;
-    metadata << "Electron LifeTime : " << fElectronLifeTime * ns << " ns" << endl;
-    metadata << "Longitudinal Diffusion : " << fLongitudinalDiffusion << " (cm)^1/2" << endl;
-    metadata << "Transversal Diffusion : " << fTransversalDiffusion << " (cm)^1/2" << endl;
-    metadata << "******************************************" << endl;
-    metadata << endl;
-    metadata << endl;
+    RESTMetadata << "Drift Volume Material : " << fMaterial << ", W-value : " << fW << " eV" << RESTendl;
+    RESTMetadata << "Electric Field : " << fElectricField * V / cm << " V/cm " << RESTendl;
+    RESTMetadata << "Drift Speed : " << fDriftVelocity * mm / us << " mm/us" << RESTendl;
+    RESTMetadata << "Electron LifeTime : " << fElectronLifeTime * ns << " ns" << RESTendl;
+    RESTMetadata << "Longitudinal Diffusion : " << fLongitudinalDiffusion << " (cm)^1/2" << RESTendl;
+    RESTMetadata << "Transversal Diffusion : " << fTransversalDiffusion << " (cm)^1/2" << RESTendl;
+    RESTMetadata << "******************************************" << RESTendl;
+    RESTMetadata << RESTendl;
+    RESTMetadata << RESTendl;
 }

--- a/src/TRestDetectorElectronDiffusionProcess.cxx
+++ b/src/TRestDetectorElectronDiffusionProcess.cxx
@@ -70,23 +70,23 @@ void TRestDetectorElectronDiffusionProcess::InitProcess() {
     if (fGas == nullptr) {
         if (fLonglDiffCoeff == -1 || fTransDiffCoeff == -1) {
             RESTWarning << "Gas has not been initialized" << RESTendl;
-            RESTFerr << "TRestDetectorElectronDiffusionProcess: diffusion parameters are not defined in the rml "
+            RESTError << "TRestDetectorElectronDiffusionProcess: diffusion parameters are not defined in the rml "
                     "file!"
                  << RESTendl;
             exit(-1);
         }
         if (fWvalue == -1) {
             RESTWarning << "Gas has not been initialized" << RESTendl;
-            RESTFerr << "TRestDetectorElectronDiffusionProcess: gas work function has not been defined in the "
+            RESTError << "TRestDetectorElectronDiffusionProcess: gas work function has not been defined in the "
                     "rml file!"
                  << RESTendl;
             exit(-1);
         }
     } else {
 #ifndef USE_Garfield
-        RESTFerr << "A TRestDetectorGas definition was found but REST was not linked to Garfield libraries."
+        RESTError << "A TRestDetectorGas definition was found but REST was not linked to Garfield libraries."
              << RESTendl;
-        RESTFerr << "Please, remove the TRestDetectorGas definition, and add gas parameters inside the process "
+        RESTError << "Please, remove the TRestDetectorGas definition, and add gas parameters inside the process "
                 "TRestDetectorElectronDiffusionProcess"
              << RESTendl;
         exit(1);

--- a/src/TRestDetectorElectronDiffusionProcess.cxx
+++ b/src/TRestDetectorElectronDiffusionProcess.cxx
@@ -69,26 +69,26 @@ void TRestDetectorElectronDiffusionProcess::InitProcess() {
     fGas = GetMetadata<TRestDetectorGas>();
     if (fGas == nullptr) {
         if (fLonglDiffCoeff == -1 || fTransDiffCoeff == -1) {
-            warning << "Gas has not been initialized" << endl;
-            ferr << "TRestDetectorElectronDiffusionProcess: diffusion parameters are not defined in the rml "
+            RESTWarning << "Gas has not been initialized" << RESTendl;
+            RESTFerr << "TRestDetectorElectronDiffusionProcess: diffusion parameters are not defined in the rml "
                     "file!"
-                 << endl;
+                 << RESTendl;
             exit(-1);
         }
         if (fWvalue == -1) {
-            warning << "Gas has not been initialized" << endl;
-            ferr << "TRestDetectorElectronDiffusionProcess: gas work function has not been defined in the "
+            RESTWarning << "Gas has not been initialized" << RESTendl;
+            RESTFerr << "TRestDetectorElectronDiffusionProcess: gas work function has not been defined in the "
                     "rml file!"
-                 << endl;
+                 << RESTendl;
             exit(-1);
         }
     } else {
 #ifndef USE_Garfield
-        ferr << "A TRestDetectorGas definition was found but REST was not linked to Garfield libraries."
-             << endl;
-        ferr << "Please, remove the TRestDetectorGas definition, and add gas parameters inside the process "
+        RESTFerr << "A TRestDetectorGas definition was found but REST was not linked to Garfield libraries."
+             << RESTendl;
+        RESTFerr << "Please, remove the TRestDetectorGas definition, and add gas parameters inside the process "
                 "TRestDetectorElectronDiffusionProcess"
-             << endl;
+             << RESTendl;
         exit(1);
 #endif
         if (fGasPressure <= 0) fGasPressure = fGas->GetPressure();
@@ -183,13 +183,13 @@ TRestEvent* TRestDetectorElectronDiffusionProcess::ProcessEvent(TRestEvent* inpu
                             zDiff = z + fRandom->Gaus(0, longHitDiffusion);
 
                             if (fUnitElectronEnergy) {
-                                if (GetVerboseLevel() >= REST_Extreme)
+                                if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme)
                                     cout << "Adding hit. x : " << xDiff << " y : " << yDiff
                                          << " z : " << zDiff << " (unit energy)" << endl;
                                 fOutputHitsEvent->AddHit(xDiff, yDiff, zDiff, 1, hits->GetTime(n),
                                                          hits->GetType(n));
                             } else {
-                                if (GetVerboseLevel() >= REST_Extreme)
+                                if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme)
                                     cout << "Adding hit. x : " << xDiff << " y : " << yDiff
                                          << " z : " << zDiff
                                          << " en : " << localWValue * REST_Units::keV / REST_Units::eV
@@ -205,14 +205,14 @@ TRestEvent* TRestDetectorElectronDiffusionProcess::ProcessEvent(TRestEvent* inpu
         }
     }
 
-    if (this->GetVerboseLevel() >= REST_Debug) {
+    if (this->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "TRestDetectorElectronDiffusionProcess. Input hits energy : " << fInputHitsEvent->GetEnergy()
              << endl;
         cout << "TRestDetectorElectronDiffusionProcess. Hits added : " << fOutputHitsEvent->GetNumberOfHits()
              << endl;
         cout << "TRestDetectorElectronDiffusionProcess. Hits total energy : " << fOutputHitsEvent->GetEnergy()
              << endl;
-        if (GetVerboseLevel() >= REST_Extreme) GetChar();
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) GetChar();
     }
 
     return fOutputHitsEvent;
@@ -236,16 +236,16 @@ void TRestDetectorElectronDiffusionProcess::InitFromConfigFile() {
     if (fLonglDiffCoeff == -1)
         fLonglDiffCoeff = StringToDouble(GetParameter("longDiff", "-1"));
     else {
-        warning << "longitudinalDiffusionCoeffient is now OBSOLETE! It will soon dissapear." << endl;
-        warning << " Please use the shorter form of this parameter : longDiff" << endl;
+        RESTWarning << "longitudinalDiffusionCoeffient is now OBSOLETE! It will soon dissapear." << RESTendl;
+        RESTWarning << " Please use the shorter form of this parameter : longDiff" << RESTendl;
     }
 
     fTransDiffCoeff = StringToDouble(GetParameter("transversalDiffusionCoefficient", "-1"));
     if (fTransDiffCoeff == -1)
         fTransDiffCoeff = StringToDouble(GetParameter("transDiff", "-1"));
     else {
-        warning << "transversalDiffusionCoeffient is now OBSOLETE! It will soon dissapear." << endl;
-        warning << " Please use the shorter form of this parameter : transDiff" << endl;
+        RESTWarning << "transversalDiffusionCoeffient is now OBSOLETE! It will soon dissapear." << RESTendl;
+        RESTWarning << " Please use the shorter form of this parameter : transDiff" << RESTendl;
     }
     fMaxHits = StringToInteger(GetParameter("maxHits", "1000"));
     fSeed = StringToDouble(GetParameter("seed", "0"));

--- a/src/TRestDetectorFiducializationProcess.cxx
+++ b/src/TRestDetectorFiducializationProcess.cxx
@@ -81,7 +81,7 @@ TRestEvent* TRestDetectorFiducializationProcess::ProcessEvent(TRestEvent* inputE
 
     if (fOutputHitsEvent->GetNumberOfHits() == 0) return nullptr;
 
-    if (this->GetVerboseLevel() >= REST_Debug) {
+    if (this->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "TRestDetectorFiducializationProcess. Hits added : " << fOutputHitsEvent->GetNumberOfHits()
              << endl;
         cout << "TRestDetectorFiducializationProcess. Hits total energy : " << fOutputHitsEvent->GetEnergy()

--- a/src/TRestDetectorGarfieldDriftProcess.cxx
+++ b/src/TRestDetectorGarfieldDriftProcess.cxx
@@ -153,14 +153,14 @@ void TRestDetectorGarfieldDriftProcess::InitProcess() {
     fGeometry->DefaultColors();
     //         fGeometry->UpdateElements();
 
-    cout << "TRestDetectorGarfieldDriftProcess  GetVerboseLevel : " << this->GetVerboseLevel() << endl;
+    cout << "TRestDetectorGarfieldDriftProcess  GetVerboseLevel : " << static_cast<int>(this->GetVerboseLevel()) << endl;
 
     // analyze GDML geometry to find major elements (gas volume, electrodes,
     // readout)
     TObjArray* thenodes = geovol->GetNodes();
     for (TIter it = thenodes->begin(); it != thenodes->end(); ++it) {
         TGeoNode* itnode = (TGeoNode*)(*it);
-        if (GetVerboseLevel() >= REST_Info) {
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Info) {
             cout << "****** itnode " << itnode->GetName() << endl;
             itnode->PrintCandidates();
         }
@@ -168,7 +168,7 @@ void TRestDetectorGarfieldDriftProcess::InitProcess() {
         itnode->PrintCandidates();
 
         TGeoVolume* itvol = itnode->GetVolume();
-        if (GetVerboseLevel() >= REST_Info) {
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Info) {
             cout << "  *  *  itvolume " << itvol->GetName() << endl;
             itvol->Print();
         }
@@ -176,12 +176,12 @@ void TRestDetectorGarfieldDriftProcess::InitProcess() {
         itvol->Print();
 
         TGeoMedium* itmed = itvol->GetMedium();
-        if (GetVerboseLevel() >= REST_Info) cout << "  *  *  itmed " << itmed->GetName() << endl;
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Info) cout << "  *  *  itmed " << itmed->GetName() << endl;
 
         // gas volume
         if (fGas->GetGDMLMaterialRef() == itmed->GetName()) {
             fGeometry->SetGfGeoMedium(itmed->GetName(), fGas);
-            if (GetVerboseLevel() >= REST_Info) {
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Info) {
                 cout << "  -> gas volume   SetMedium itmed " << itmed->GetName() << "  fGas "
                      << fGas->GetGasMedium()->GetName() << endl;
                 fGas->GetGasMedium()->PrintGas();
@@ -195,14 +195,14 @@ void TRestDetectorGarfieldDriftProcess::InitProcess() {
         if ((strncmp(itvol->GetName(), "anodeVol", 8) == 0) ||
             (strncmp(itvol->GetName(), "cathodeVol", 10) == 0)) {
             fGeometry->SetDriftElecNode(itnode);
-            if (GetVerboseLevel() >= REST_Info) cout << "  -> cathode volume " << endl;
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Info) cout << "  -> cathode volume " << endl;
             cout << "  -> cathode volume " << endl;
         }
 
         // micromegas readout electrode
         if ((strncmp(itvol->GetName(), "micromegasVol", 13) == 0)) {
             fGeometry->AddReadoutElecNode(itnode);
-            if (GetVerboseLevel() >= REST_Info) cout << "  -> readout volume " << endl;
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Info) cout << "  -> readout volume " << endl;
             cout << "  -> readout volume " << endl;
         }
     }
@@ -342,7 +342,7 @@ TRestEvent* TRestDetectorGarfieldDriftProcess::ProcessEvent(TRestEvent* inputEve
     double xi, yi, zi, ti, xf, yf, zf, tf, energyf;
     int status;
 
-    if (GetVerboseLevel() >= REST_Debug) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "Number of hits : " << fInputHitsEvent->GetNumberOfHits() << endl;
         cout << "--------------------------" << endl;
         fInputHitsEvent->PrintEvent(20);
@@ -412,7 +412,7 @@ TRestEvent* TRestDetectorGarfieldDriftProcess::ProcessEvent(TRestEvent* inputEve
 
     // fSignalEvent->PrintEvent();
 
-    if (GetVerboseLevel() >= REST_Debug) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "TRestDetectorElectronDiffusionProcess. Hits added : " << fOutputHitsEvent->GetNumberOfHits()
              << endl;
         cout << "TRestDetectorElectronDiffusionProcess. Hits total energy : " << fOutputHitsEvent->GetEnergy()
@@ -425,7 +425,7 @@ TRestEvent* TRestDetectorGarfieldDriftProcess::ProcessEvent(TRestEvent* inputEve
 #else
     fInputHitsEvent = (TRestDetectorHitsEvent*)inputEvent;
     fOutputHitsEvent = fInputHitsEvent;
-    debug << "nullptr process" << endl;
+    RESTDebug << "nullptr process" << RESTendl;
     return inputEvent;
 
 #endif

--- a/src/TRestDetectorGas.cxx
+++ b/src/TRestDetectorGas.cxx
@@ -268,7 +268,7 @@ TRestDetectorGas::TRestDetectorGas(const char* configFilename, string name, bool
 /// \brief TRestDetectorGas default destructor
 ///
 TRestDetectorGas::~TRestDetectorGas() {
-    debug << "Entering ... TRestDetectorGas() destructor." << endl;
+    RESTDebug << "Entering ... TRestDetectorGas() destructor." << RESTendl;
 
 #if defined USE_Garfield
     delete fGasMedium;
@@ -280,7 +280,7 @@ TRestDetectorGas::~TRestDetectorGas() {
 /// members.
 ///
 void TRestDetectorGas::Initialize() {
-    debug << "TRestDetectorGas. Entering ... Initialize()." << endl;
+    RESTDebug << "TRestDetectorGas. Entering ... Initialize()." << RESTendl;
 
     SetSectionName(this->ClassName());
     SetLibraryVersion(LIBRARY_VERSION);
@@ -325,13 +325,13 @@ void TRestDetectorGas::Initialize() {
 /// using EnableGasGeneration() or at the class construction time.
 ///
 void TRestDetectorGas::LoadGasFile() {
-    debug << "Entering ... TRestDetectorGas::LoadGasFile()." << endl;
+    RESTDebug << "Entering ... TRestDetectorGas::LoadGasFile()." << RESTendl;
 
 #if defined USE_Garfield
-    debug << "fGasFilename = " << fGasFilename << endl;
+    RESTDebug << "fGasFilename = " << fGasFilename << RESTendl;
     if (!TRestTools::fileExists((string)(fGasFilename))) {
-        ferr << __PRETTY_FUNCTION__ << endl;
-        ferr << "The gas file does not exist. (name:" << fGasFilename << ")" << endl;
+        RESTFerr << __PRETTY_FUNCTION__ << RESTendl;
+        RESTFerr << "The gas file does not exist. (name:" << fGasFilename << ")" << RESTendl;
         fStatus = RESTGAS_ERROR;
         return;
     }
@@ -344,10 +344,10 @@ void TRestDetectorGas::LoadGasFile() {
     fGasMedium->GetFieldGrid(fEFields, fBFields, fAngles);
 
     fStatus = RESTGAS_GASFILE_LOADED;
-    info << "TRestDetectorGas. Gas file loaded!" << endl;
+    RESTInfo << "TRestDetectorGas. Gas file loaded!" << RESTendl;
 
     for (unsigned int i = 0; i < fEFields.size(); i++)
-        debug << "node " << i << " Field : " << fEFields[i] << " V/cm" << endl;
+        RESTDebug << "node " << i << " Field : " << fEFields[i] << " V/cm" << RESTendl;
 
     if (fGasMedium && fGasMedium->GetW() == 0.) {
         fGasMedium->SetW(GetWvalue());
@@ -358,8 +358,8 @@ void TRestDetectorGas::LoadGasFile() {
 }
 
 void TRestDetectorGas::CalcGarField(double Emin, double Emax, int n) {
-    debug << "Entering ... TRestDetectorGas::CalcGarField( Emin=" << Emin << " , Emax=" << Emax << " )"
-          << endl;
+    RESTDebug << "Entering ... TRestDetectorGas::CalcGarField( Emin=" << Emin << " , Emax=" << Emax << " )"
+          << RESTendl;
 
 #if defined USE_Garfield
     if (fEnodes <= 0) {
@@ -403,7 +403,7 @@ void TRestDetectorGas::CalcGarField(double Emin, double Emax, int n) {
     fGasMedium->SetTemperature(fTemperatureInK);
 
     if (fPressureInAtm != 1)
-        warning << "-- Warning : The gas will be generated for gas pressure = 1atm" << endl;
+        RESTWarning << "-- Warning : The gas will be generated for gas pressure = 1atm" << RESTendl;
 
     fGasMedium->SetPressure(1 * REST_Units::torr);
 
@@ -413,13 +413,13 @@ void TRestDetectorGas::CalcGarField(double Emin, double Emax, int n) {
 
     cout << "Garfield: calculating..." << endl;
 
-    if (fVerboseLevel >= REST_Info) fGasMedium->EnableDebugging();
+    if (fVerboseLevel >= TRestStringOutput::REST_Verbose_Level::REST_Info) fGasMedium->EnableDebugging();
     fGasMedium->Initialise();
-    if (fVerboseLevel >= REST_Info) fGasMedium->DisableDebugging();
+    if (fVerboseLevel >= TRestStringOutput::REST_Verbose_Level::REST_Info) fGasMedium->DisableDebugging();
 
     fGasMedium->GenerateGasTable(fNCollisions, true);
     if (fPressureInAtm != 1) {
-        warning << "-- Warning : Restoring the gas pressure" << endl;
+        RESTWarning << "-- Warning : Restoring the gas pressure" << RESTendl;
         fGasMedium->SetPressure(fPressureInAtm * 760.);
     }
 #else
@@ -439,8 +439,8 @@ void TRestDetectorGas::CalcGarField(double Emin, double Emax, int n) {
 /// \param fraction The element fraction in volume.
 ///
 void TRestDetectorGas::AddGasComponent(string gasName, Double_t fraction) {
-    debug << "Entering ... TRestDetectorGas::AddGasComponent( gasName=" << gasName
-          << " , fraction=" << fraction << " )" << endl;
+    RESTDebug << "Entering ... TRestDetectorGas::AddGasComponent( gasName=" << gasName
+          << " , fraction=" << fraction << " )" << RESTendl;
 
     fGasComponentName.push_back(gasName);
     fGasComponentFraction.push_back(fraction);
@@ -452,11 +452,11 @@ void TRestDetectorGas::AddGasComponent(string gasName, Double_t fraction) {
 // photoncrossection database is not available
 void TRestDetectorGas::GetGasWorkFunction() {
 #if defined USE_Garfield
-    essential << __PRETTY_FUNCTION__ << endl;
-    essential << "This method has never been validated to operate properly" << endl;
-    essential << "If we manage to make it work we could use this method to "
+    RESTEssential << __PRETTY_FUNCTION__ << RESTendl;
+    RESTEssential << "This method has never been validated to operate properly" << RESTendl;
+    RESTEssential << "If we manage to make it work we could use this method to "
                  "obtain the calculated W of the gas"
-              << endl;
+              << RESTendl;
 
     // Gas gap [cm].
     const double width = 1.;
@@ -505,7 +505,7 @@ void TRestDetectorGas::GetGasWorkFunction() {
 void TRestDetectorGas::InitFromConfigFile() {
     // if (GetVerboseLevel() <= REST_Info) fVerboseLevel = REST_Info;
 
-    debug << "Entering ... TRestDetectorGas::InitFromConfigFile()" << endl;
+    RESTDebug << "Entering ... TRestDetectorGas::InitFromConfigFile()" << RESTendl;
 
     // read config parameters of base class
     TRestDetectorDriftVolume::InitFromConfigFile();
@@ -538,14 +538,14 @@ void TRestDetectorGas::InitFromConfigFile() {
         }
     }
     if (fNofGases == 0) {
-        ferr << "TRestDetectorGas: No gas components added!" << endl;
+        RESTFerr << "TRestDetectorGas: No gas components added!" << RESTendl;
     }
     double sum = 0;
     for (int i = 0; i < fNofGases; i++) sum += GetGasComponentFraction(i);
     if (sum - 1 < 1.e12)
         fStatus = RESTGAS_CFG_LOADED;
     else {
-        warning << "TRestDetectorGas : The total gas fractions is NOT 1." << endl;
+        RESTWarning << "TRestDetectorGas : The total gas fractions is NOT 1." << RESTendl;
         fStatus = RESTGAS_ERROR;
         return;
     }
@@ -561,43 +561,43 @@ void TRestDetectorGas::InitFromConfigFile() {
         fGasGeneration = true;
     fGasOutputPath = GetParameter("gasOutputPath", "./");
     if (!TRestTools::isPathWritable((string)fGasOutputPath)) {
-        warning << "-- Warning : The specified gasOutputPath is not writable!" << endl;
-        warning << "-- Warning : The output path will be changed to ./" << endl;
+        RESTWarning << "-- Warning : The specified gasOutputPath is not writable!" << RESTendl;
+        RESTWarning << "-- Warning : The output path will be changed to ./" << RESTendl;
         fGasOutputPath = "./";
     }
     fGDMLMaterialRef = GetParameter("GDMLMaterialRef", "");
 
     // construct the gas file name and try to find it, either locally or from gas server
     fGasFilename = ConstructFilename();
-    debug << "TRestDetectorGas::InitFromConfigFile. ConstructFilename. fGasFilename = " << fGasFilename
-          << endl;
+    RESTDebug << "TRestDetectorGas::InitFromConfigFile. ConstructFilename. fGasFilename = " << fGasFilename
+          << RESTendl;
     fGasFilename = FindGasFile((string)fGasFilename);
-    debug << "TRestDetectorGas::InitFromConfigFile. FindGasFile. fGasFilename = " << fGasFilename << endl;
+    RESTDebug << "TRestDetectorGas::InitFromConfigFile. FindGasFile. fGasFilename = " << fGasFilename << RESTendl;
 
     // If we found the gasFile then obviously we disable the gas generation
     if (fGasGeneration && TRestTools::fileExists((string)fGasFilename)) {
         fGasGeneration = false;
 
-        warning << "TRestDetectorGas gasFile generation is enabled, but the "
+        RESTWarning << "TRestDetectorGas gasFile generation is enabled, but the "
                    "gasFile already exists!!"
-                << endl;
-        warning << "Filename : " << fGasFilename << endl;
-        warning << "fGasGeneration should be disabled to remove this "
+                << RESTendl;
+        RESTWarning << "Filename : " << fGasFilename << RESTendl;
+        RESTWarning << "fGasGeneration should be disabled to remove this "
                    "warning."
-                << endl;
-        warning << "If you really want to re-generate the gas file you "
+                << RESTendl;
+        RESTWarning << "If you really want to re-generate the gas file you "
                    "will need to disable the gasServer."
-                << endl;
-        warning << "And/or remove any local copies that are found by "
+                << RESTendl;
+        RESTWarning << "And/or remove any local copies that are found by "
                    "SearchPath."
-                << endl;
+                << RESTendl;
     }
     fStatus = RESTGAS_CFG_LOADED;
 
 #if defined USE_Garfield
     // calling garfield, either to generate gas file or load existing gas file
     if (fGasGeneration) {
-        essential << "Starting gas generation" << endl;
+        RESTEssential << "Starting gas generation" << RESTendl;
 
         CalcGarField(fEmin, fEmax, fEnodes);
         GenerateGasFile();
@@ -610,11 +610,11 @@ void TRestDetectorGas::InitFromConfigFile() {
         fGasMedium->SetW(fW);  // as it is probably not computed by Magboltz
 #endif
 
-    if (GetVerboseLevel() >= REST_Info) PrintGasInfo();
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Info) PrintGasInfo();
 }
 
 void TRestDetectorGas::InitFromRootFile() {
-    debug << "Entering ... TRestDetectorGas::InitFromRootFile()" << endl;
+    RESTDebug << "Entering ... TRestDetectorGas::InitFromRootFile()" << RESTendl;
     TRestMetadata::InitFromRootFile();
     if (fGasFileContent != "")  // use gas file content by default
     {
@@ -634,18 +634,18 @@ void TRestDetectorGas::InitFromRootFile() {
 }
 
 void TRestDetectorGas::UploadGasToServer(string absoluteGasFilename) {
-    essential << "uploading gas file and gas definition rmls" << endl;
+    RESTEssential << "uploading gas file and gas definition rmls" << RESTendl;
 
     if (!fTest && (fMaxElectronEnergy < 400 || fNCollisions < 10 || fEnodes < 20)) {
-        warning << "-- Warning : The gas file does not fulfill the requirements "
+        RESTWarning << "-- Warning : The gas file does not fulfill the requirements "
                    "for being uploaded to the gasServer"
-                << endl;
-        warning << "-- Warning : maxElectronEnergy >= 400. Number of collisions >= "
+                << RESTendl;
+        RESTWarning << "-- Warning : maxElectronEnergy >= 400. Number of collisions >= "
                    "10. Number of E nodes >= 20."
-                << endl;
-        warning << "-- Warning : The generated file will NOT be uploaded to the "
+                << RESTendl;
+        RESTWarning << "-- Warning : The generated file will NOT be uploaded to the "
                    "server but preserved locally."
-                << endl;
+                << RESTendl;
         return;
     }
 
@@ -668,8 +668,8 @@ void TRestDetectorGas::UploadGasToServer(string absoluteGasFilename) {
     a = system(cmd.c_str());
 
     if (a != 0) {
-        ferr << "-- Error : " << __PRETTY_FUNCTION__ << endl;
-        ferr << "-- Error : problem removing last line from " << fname << endl;
+        RESTFerr << "-- Error : " << __PRETTY_FUNCTION__ << RESTendl;
+        RESTFerr << "-- Error : problem removing last line from " << fname << RESTendl;
         return;
     }
 
@@ -711,7 +711,7 @@ void TRestDetectorGas::UploadGasToServer(string absoluteGasFilename) {
     //    return;
     //}
 
-    success << "-- Sucess : Gasfile server database was updated sucessfully!!" << endl;
+    RESTSuccess << "-- Sucess : Gasfile server database was updated sucessfully!!" << RESTendl;
 }
 
 /////////////////////////////////////////////
@@ -729,7 +729,7 @@ void TRestDetectorGas::UploadGasToServer(string absoluteGasFilename) {
 ///
 ///
 string TRestDetectorGas::FindGasFile(string name) {
-    debug << "Entering ... TRestDetectorGas::FindGasFile( name=" << name << " )" << endl;
+    RESTDebug << "Entering ... TRestDetectorGas::FindGasFile( name=" << name << " )" << RESTendl;
 
     string absoluteName = "";
 
@@ -738,18 +738,18 @@ string TRestDetectorGas::FindGasFile(string name) {
     }
 
     if (absoluteName == "") {
-        info << "Trying to find the gasFile locally" << endl;
+        RESTInfo << "Trying to find the gasFile locally" << RESTendl;
         absoluteName = SearchFile(name);
         if (absoluteName == "") {
-            warning << "-- Warning : No sucess finding local gas file definition." << endl;
-            warning << "-- Warning : Gas file definition does not exist." << endl;
-            info << "To generate a new gasFile enable gas generation in TRestDetectorGas "
+            RESTWarning << "-- Warning : No sucess finding local gas file definition." << RESTendl;
+            RESTWarning << "-- Warning : Gas file definition does not exist." << RESTendl;
+            RESTInfo << "To generate a new gasFile enable gas generation in TRestDetectorGas "
                     "constructor"
-                 << endl;
-            info << "TRestDetectorGas ( \"gasDefinition.rml\", \"gas Name\", true );" << endl;
-            info << "Further details can be found at TRestDetectorGas class definition and "
+                 << RESTendl;
+            RESTInfo << "TRestDetectorGas ( \"gasDefinition.rml\", \"gas Name\", true );" << RESTendl;
+            RESTInfo << "Further details can be found at TRestDetectorGas class definition and "
                     "tutorial."
-                 << endl;
+                 << RESTendl;
 
             absoluteName = name;
         }
@@ -762,7 +762,7 @@ string TRestDetectorGas::FindGasFile(string name) {
 /// \brief Returns a string definning the gas components and fractions.
 ///
 TString TRestDetectorGas::GetGasMixture() {
-    debug << "Entering ... TRestDetectorGas::GetGasMixture( )" << endl;
+    RESTDebug << "Entering ... TRestDetectorGas::GetGasMixture( )" << RESTendl;
 
     TString gasMixture;
     char tmpStr[64];
@@ -782,7 +782,7 @@ TString TRestDetectorGas::GetGasMixture() {
 /// This method returns only the filename without including absolute or relative
 /// paths.
 string TRestDetectorGas::ConstructFilename() {
-    debug << "Entering ... TRestDetectorGas::ConstructFilename( )" << endl;
+    RESTDebug << "Entering ... TRestDetectorGas::ConstructFilename( )" << RESTendl;
 
     string name = "";
     char tmpStr[256];
@@ -823,29 +823,29 @@ string TRestDetectorGas::ConstructFilename() {
 
     name += ".gas";
 
-    debug << "Constructed filename : " << name << endl;
+    RESTDebug << "Constructed filename : " << name << RESTendl;
     return name;
 }
 
 /////////////////////////////////////////////
 /// \brief Save a gas file with a structured file name
 void TRestDetectorGas::GenerateGasFile() {
-    debug << "Entering ... TRestDetectorGas::GenerateGasFile( )" << endl;
+    RESTDebug << "Entering ... TRestDetectorGas::GenerateGasFile( )" << RESTendl;
 
 #if defined USE_Garfield
 
     fGasFilename = ConstructFilename();
-    debug << " TRestDetectorGas::GenerateGasFile. fGasFilename = " << fGasFilename << endl;
+    RESTDebug << " TRestDetectorGas::GenerateGasFile. fGasFilename = " << fGasFilename << RESTendl;
 
     if (!TRestTools::isPathWritable((string)fGasOutputPath)) {
         cout << endl;
-        warning << "-- Warning: REST ERROR. TRestDetectorGas. Path is not writtable." << endl;
-        warning << "-- Warning: Path : " << fGasOutputPath << endl;
-        warning << "-- Warning: Make sure the final data path is writtable before "
+        RESTWarning << "-- Warning: REST ERROR. TRestDetectorGas. Path is not writtable." << RESTendl;
+        RESTWarning << "-- Warning: Path : " << fGasOutputPath << RESTendl;
+        RESTWarning << "-- Warning: Make sure the final data path is writtable before "
                    "proceed to gas generation."
-                << endl;
-        warning << "-- Warning: or change the gas data path ... " << endl;
-        warning << endl;
+                << RESTendl;
+        RESTWarning << "-- Warning: or change the gas data path ... " << RESTendl;
+        RESTWarning << RESTendl;
         GetChar();
         return;
     }
@@ -874,7 +874,7 @@ void TRestDetectorGas::GenerateGasFile() {
 /// \param pressure The new pressure of the gas in atm.
 ///
 void TRestDetectorGas::SetPressure(Double_t pressure) {
-    debug << "Entering ... TRestDetectorGas::SetPressure( pressure=" << pressure << " )" << endl;
+    RESTDebug << "Entering ... TRestDetectorGas::SetPressure( pressure=" << pressure << " )" << RESTendl;
 
     fPressureInAtm = pressure;
 #if defined USE_Garfield
@@ -885,7 +885,7 @@ void TRestDetectorGas::SetPressure(Double_t pressure) {
 /////////////////////////////////////////////
 /// \brief Defines the temperature of the gas.
 void TRestDetectorGas::SetTemperature(Double_t temperature) {
-    debug << "Entering ... TRestDetectorGas::SetPressure( temperature=" << temperature << " )" << endl;
+    RESTDebug << "Entering ... TRestDetectorGas::SetPressure( temperature=" << temperature << " )" << RESTendl;
 
     fTemperatureInK = temperature;
 #if defined USE_Garfield
@@ -902,8 +902,8 @@ void TRestDetectorGas::SetTemperature(Double_t temperature) {
 /// \param steps Number of points to be given to be drawn
 ///
 void TRestDetectorGas::PlotDriftVelocity(Double_t eMin, Double_t eMax, Int_t nSteps) {
-    debug << "Entering ... TRestDetectorGas::PlotDriftVelocity( eMin=" << eMin << " , eMax=" << eMax
-          << ", nSteps=" << nSteps << " )" << endl;
+    RESTDebug << "Entering ... TRestDetectorGas::PlotDriftVelocity( eMin=" << eMin << " , eMax=" << eMax
+          << ", nSteps=" << nSteps << " )" << RESTendl;
 
     vector<Double_t> eField(nSteps), driftVel(nSteps);
 
@@ -935,8 +935,8 @@ void TRestDetectorGas::PlotDriftVelocity(Double_t eMin, Double_t eMax, Int_t nSt
 /// \param steps Number of points to be given to be drawn
 ///
 void TRestDetectorGas::PlotLongitudinalDiffusion(Double_t eMin, Double_t eMax, Int_t nSteps) {
-    debug << "Entering ... TRestDetectorGas::PlotLongitudinalDiffusion( eMin=" << eMin << " , eMax=" << eMax
-          << ", nSteps=" << nSteps << " )" << endl;
+    RESTDebug << "Entering ... TRestDetectorGas::PlotLongitudinalDiffusion( eMin=" << eMin << " , eMax=" << eMax
+          << ", nSteps=" << nSteps << " )" << RESTendl;
 
     vector<Double_t> eField(nSteps), longDiff(nSteps);
 
@@ -968,8 +968,8 @@ void TRestDetectorGas::PlotLongitudinalDiffusion(Double_t eMin, Double_t eMax, I
 /// \param steps Number of points to be given to be drawn
 ///
 void TRestDetectorGas::PlotTransversalDiffusion(Double_t eMin, Double_t eMax, Int_t nSteps) {
-    debug << "Entering ... TRestDetectorGas::PlotTransversalDiffusion( eMin=" << eMin << " , eMax=" << eMax
-          << ", nSteps=" << nSteps << " )" << endl;
+    RESTDebug << "Entering ... TRestDetectorGas::PlotTransversalDiffusion( eMin=" << eMin << " , eMax=" << eMax
+          << ", nSteps=" << nSteps << " )" << RESTendl;
 
     vector<Double_t> eField(nSteps), transDiff(nSteps);
 
@@ -1001,8 +1001,8 @@ void TRestDetectorGas::PlotTransversalDiffusion(Double_t eMin, Double_t eMax, In
 /// \param steps Number of points to be given to be drawn
 ///
 void TRestDetectorGas::PlotTownsendCoefficient(Double_t eMin, Double_t eMax, Int_t nSteps) {
-    debug << "Entering ... TRestDetectorGas::PlotTownsendCoefficient( eMin=" << eMin << " , eMax=" << eMax
-          << ", nSteps=" << nSteps << " )" << endl;
+    RESTDebug << "Entering ... TRestDetectorGas::PlotTownsendCoefficient( eMin=" << eMin << " , eMax=" << eMax
+          << ", nSteps=" << nSteps << " )" << RESTendl;
 
     vector<Double_t> eField(nSteps), townsendCoeff(nSteps);
 
@@ -1029,17 +1029,17 @@ void TRestDetectorGas::PlotTownsendCoefficient(Double_t eMin, Double_t eMax, Int
 /// V/cm.
 ///
 Double_t TRestDetectorGas::GetDriftVelocity(Double_t E) const {
-    debug << "Entering ... TRestDetectorGas::GetDriftVelocity( E=" << E << " )" << endl;
+    RESTDebug << "Entering ... TRestDetectorGas::GetDriftVelocity( E=" << E << " )" << RESTendl;
 
 #if defined USE_Garfield
     if (fStatus != RESTGAS_GASFILE_LOADED) {
-        debug << "-- Error : " << __PRETTY_FUNCTION__ << endl;
-        debug << "-- Error : Gas file was not loaded!" << endl;
+        RESTDebug << "-- Error : " << __PRETTY_FUNCTION__ << RESTendl;
+        RESTDebug << "-- Error : Gas file was not loaded!" << RESTendl;
         return 0;
     }
 
-    info << "Calling Garfield directly. Please be aware that the unit is different"
-         << "from REST standard unit. E is V/cm. The return is cm/us" << endl;
+    RESTInfo << "Calling Garfield directly. Please be aware that the unit is different"
+         << "from REST standard unit. E is V/cm. The return is cm/us" << RESTendl;
 
     Double_t vx, vy, vz;
     fGasMedium->ElectronVelocity(0., 0, -E, 0, 0, 0, vx, vy, vz);
@@ -1058,17 +1058,17 @@ Double_t TRestDetectorGas::GetDriftVelocity(Double_t E) const {
 /// electric field in V/cm.
 ///
 Double_t TRestDetectorGas::GetLongitudinalDiffusion(Double_t E) const {
-    debug << "Entering ... TRestDetectorGas::GetLongitudinalDiffusion( E=" << E << " )" << endl;
+    RESTDebug << "Entering ... TRestDetectorGas::GetLongitudinalDiffusion( E=" << E << " )" << RESTendl;
 
 #if defined USE_Garfield
     if (fStatus != RESTGAS_GASFILE_LOADED) {
-        debug << "-- Error : " << __PRETTY_FUNCTION__ << endl;
-        debug << "-- Error : Gas file was not loaded!" << endl;
+        RESTDebug << "-- Error : " << __PRETTY_FUNCTION__ << RESTendl;
+        RESTDebug << "-- Error : Gas file was not loaded!" << RESTendl;
         return 0;
     }
 
-    info << "Calling Garfield directly. Please be aware that the unit is different"
-         << "from REST standard unit. E is V/cm. The return is cm^1/2" << endl;
+    RESTInfo << "Calling Garfield directly. Please be aware that the unit is different"
+         << "from REST standard unit. E is V/cm. The return is cm^1/2" << RESTendl;
 
     Double_t dl, dt;
     fGasMedium->ElectronDiffusion(0., 0, -E, 0, 0, 0, dl, dt);
@@ -1087,17 +1087,17 @@ Double_t TRestDetectorGas::GetLongitudinalDiffusion(Double_t E) const {
 /// field in V/cm.
 ///
 Double_t TRestDetectorGas::GetTransversalDiffusion(Double_t E) const {
-    debug << "Entering ... TRestDetectorGas::GetTransversalDiffusion( E=" << E << " )" << endl;
+    RESTDebug << "Entering ... TRestDetectorGas::GetTransversalDiffusion( E=" << E << " )" << RESTendl;
 
 #if defined USE_Garfield
     if (fStatus != RESTGAS_GASFILE_LOADED) {
-        debug << "-- Error : " << __PRETTY_FUNCTION__ << endl;
-        debug << "-- Error : Gas file was not loaded!" << endl;
+        RESTDebug << "-- Error : " << __PRETTY_FUNCTION__ << RESTendl;
+        RESTDebug << "-- Error : Gas file was not loaded!" << RESTendl;
         return 0;
     }
 
-    info << "Calling Garfield directly. Please be aware that the unit is different"
-         << "from REST standard unit. E is V/cm. The return is cm^1/2" << endl;
+    RESTInfo << "Calling Garfield directly. Please be aware that the unit is different"
+         << "from REST standard unit. E is V/cm. The return is cm^1/2" << RESTendl;
 
     Double_t dl, dt;
     fGasMedium->ElectronDiffusion(0., 0, -E, 0, 0, 0, dl, dt);
@@ -1116,17 +1116,17 @@ Double_t TRestDetectorGas::GetTransversalDiffusion(Double_t E) const {
 /// V/cm.
 ///
 Double_t TRestDetectorGas::GetTownsendCoefficient(Double_t E) const {
-    debug << "Entering ... TRestDetectorGas::GetTownsendCoefficient( E=" << E << " )" << endl;
+    RESTDebug << "Entering ... TRestDetectorGas::GetTownsendCoefficient( E=" << E << " )" << RESTendl;
 
 #if defined USE_Garfield
     if (fStatus != RESTGAS_GASFILE_LOADED) {
-        debug << "-- Error : " << __PRETTY_FUNCTION__ << endl;
-        debug << "-- Error : Gas file was not loaded!" << endl;
+        RESTDebug << "-- Error : " << __PRETTY_FUNCTION__ << RESTendl;
+        RESTDebug << "-- Error : Gas file was not loaded!" << RESTendl;
         return 0;
     }
 
-    info << "Calling Garfield directly. Please be aware that the unit is different"
-         << "from REST standard unit. E is V/cm. The return is V/cm" << endl;
+    RESTInfo << "Calling Garfield directly. Please be aware that the unit is different"
+         << "from REST standard unit. E is V/cm. The return is V/cm" << RESTendl;
 
     Double_t alpha;
     fGasMedium->ElectronTownsend(0., 0, -E, 0, 0, 0, alpha);
@@ -1145,17 +1145,17 @@ Double_t TRestDetectorGas::GetTownsendCoefficient(Double_t E) const {
 /// V/cm.
 ///
 Double_t TRestDetectorGas::GetAttachmentCoefficient(Double_t E) const {
-    debug << "Entering ... TRestDetectorGas::GetAttachmentCoefficient( E=" << E << " )" << endl;
+    RESTDebug << "Entering ... TRestDetectorGas::GetAttachmentCoefficient( E=" << E << " )" << RESTendl;
 
 #if defined USE_Garfield
     if (fStatus != RESTGAS_GASFILE_LOADED) {
-        debug << "-- Error : " << __PRETTY_FUNCTION__ << endl;
-        debug << "-- Error : Gas file was not loaded!" << endl;
+        RESTDebug << "-- Error : " << __PRETTY_FUNCTION__ << RESTendl;
+        RESTDebug << "-- Error : Gas file was not loaded!" << RESTendl;
         return 0;
     }
 
-    info << "Calling Garfield directly. Please be aware that the unit is different"
-         << "from REST standard unit. E is V/cm. The return is V/cm" << endl;
+    RESTInfo << "Calling Garfield directly. Please be aware that the unit is different"
+         << "from REST standard unit. E is V/cm. The return is V/cm" << RESTendl;
 
     Double_t eta;
     fGasMedium->ElectronAttachment(0., 0, -E, 0, 0, 0, eta);
@@ -1173,39 +1173,39 @@ Double_t TRestDetectorGas::GetAttachmentCoefficient(Double_t E) const {
 /// \brief Prints the metadata information from the gas
 ///
 void TRestDetectorGas::PrintGasInfo() {
-    debug << "Entering ... TRestDetectorGas::PrintGasInfo( )" << endl;
+    RESTDebug << "Entering ... TRestDetectorGas::PrintGasInfo( )" << RESTendl;
 
     TRestMetadata::PrintMetadata();
 
-    metadata << "Status : ";
-    if (fStatus == RESTGAS_INTITIALIZED) metadata << "Initialized";
-    if (fStatus == RESTGAS_CFG_LOADED) metadata << "Configuration loaded";
-    if (fStatus == RESTGAS_GASFILE_LOADED) metadata << "Gasfile loaded";
-    if (fStatus == RESTGAS_ERROR) metadata << "Error";
-    metadata << endl;
+    RESTMetadata << "Status : ";
+    if (fStatus == RESTGAS_INTITIALIZED) RESTMetadata << "Initialized";
+    if (fStatus == RESTGAS_CFG_LOADED) RESTMetadata << "Configuration loaded";
+    if (fStatus == RESTGAS_GASFILE_LOADED) RESTMetadata << "Gasfile loaded";
+    if (fStatus == RESTGAS_ERROR) RESTMetadata << "Error";
+    RESTMetadata << RESTendl;
 
-    metadata << "Gas filename : " << TRestTools::GetPureFileName((string)fGasFilename) << endl;
-    metadata << "Pressure : " << fPressureInAtm << " atm" << endl;
-    metadata << "Temperature : " << fTemperatureInK << " K" << endl;
-    metadata << "Electric Field : " << fElectricField * units("V/cm") << " V/cm " << endl;
-    metadata << "W-value : " << fW << " eV" << endl;
-    metadata << "Drift velocity : " << GetDriftVelocity(fElectricField * units("V/cm")) / units("cm/us")
-             << " mm/us " << endl;
-    metadata << "Max. Electron energy : " << fMaxElectronEnergy << " eV" << endl;
-    metadata << "Field grid nodes : " << fEnodes << endl;
-    metadata << "Efield range : ( " << fEmin << " , " << fEmax << " ) V/cm " << endl;
-    metadata << "Number of Gases : " << fNofGases << endl;
+    RESTMetadata << "Gas filename : " << TRestTools::GetPureFileName((string)fGasFilename) << RESTendl;
+    RESTMetadata << "Pressure : " << fPressureInAtm << " atm" << RESTendl;
+    RESTMetadata << "Temperature : " << fTemperatureInK << " K" << RESTendl;
+    RESTMetadata << "Electric Field : " << fElectricField * units("V/cm") << " V/cm " << RESTendl;
+    RESTMetadata << "W-value : " << fW << " eV" << RESTendl;
+    RESTMetadata << "Drift velocity : " << GetDriftVelocity(fElectricField * units("V/cm")) / units("cm/us")
+             << " mm/us " << RESTendl;
+    RESTMetadata << "Max. Electron energy : " << fMaxElectronEnergy << " eV" << RESTendl;
+    RESTMetadata << "Field grid nodes : " << fEnodes << RESTendl;
+    RESTMetadata << "Efield range : ( " << fEmin << " , " << fEmax << " ) V/cm " << RESTendl;
+    RESTMetadata << "Number of Gases : " << fNofGases << RESTendl;
     for (int i = 0; i < fNofGases; i++)
-        metadata << "Gas id : " << i << ", Name : " << fGasComponentName[i]
-                 << ", Fraction : " << fGasComponentFraction[i] << endl;
-    metadata << "******************************************" << endl;
-    metadata << endl;
-    metadata << endl;
+        RESTMetadata << "Gas id : " << i << ", Name : " << fGasComponentName[i]
+                 << ", Fraction : " << fGasComponentFraction[i] << RESTendl;
+    RESTMetadata << "******************************************" << RESTendl;
+    RESTMetadata << RESTendl;
+    RESTMetadata << RESTendl;
 }
 
 Int_t TRestDetectorGas::Write(const char* name, Int_t option, Int_t bufsize) {
-    debug << "Entering ... TRestDetectorGas::Write( name=" << name << " option=" << option
-          << " bufsize=" << bufsize << " )" << endl;
+    RESTDebug << "Entering ... TRestDetectorGas::Write( name=" << name << " option=" << option
+          << " bufsize=" << bufsize << " )" << RESTendl;
 
     if (fGasFileContent == "" && GasFileLoaded()) {
         ifstream infile;

--- a/src/TRestDetectorGas.cxx
+++ b/src/TRestDetectorGas.cxx
@@ -330,8 +330,8 @@ void TRestDetectorGas::LoadGasFile() {
 #if defined USE_Garfield
     RESTDebug << "fGasFilename = " << fGasFilename << RESTendl;
     if (!TRestTools::fileExists((string)(fGasFilename))) {
-        RESTFerr << __PRETTY_FUNCTION__ << RESTendl;
-        RESTFerr << "The gas file does not exist. (name:" << fGasFilename << ")" << RESTendl;
+        RESTError << __PRETTY_FUNCTION__ << RESTendl;
+        RESTError << "The gas file does not exist. (name:" << fGasFilename << ")" << RESTendl;
         fStatus = RESTGAS_ERROR;
         return;
     }
@@ -538,7 +538,7 @@ void TRestDetectorGas::InitFromConfigFile() {
         }
     }
     if (fNofGases == 0) {
-        RESTFerr << "TRestDetectorGas: No gas components added!" << RESTendl;
+        RESTError << "TRestDetectorGas: No gas components added!" << RESTendl;
     }
     double sum = 0;
     for (int i = 0; i < fNofGases; i++) sum += GetGasComponentFraction(i);
@@ -668,8 +668,8 @@ void TRestDetectorGas::UploadGasToServer(string absoluteGasFilename) {
     a = system(cmd.c_str());
 
     if (a != 0) {
-        RESTFerr << "-- Error : " << __PRETTY_FUNCTION__ << RESTendl;
-        RESTFerr << "-- Error : problem removing last line from " << fname << RESTendl;
+        RESTError << "-- Error : " << __PRETTY_FUNCTION__ << RESTendl;
+        RESTError << "-- Error : problem removing last line from " << fname << RESTendl;
         return;
     }
 

--- a/src/TRestDetectorHits3DReconstructionProcess.cxx
+++ b/src/TRestDetectorHits3DReconstructionProcess.cxx
@@ -254,12 +254,12 @@ TRestEvent* TRestDetectorHits3DReconstructionProcess::ProcessEvent(TRestEvent* i
         }
 
         if (stripehits.size() > 50) {
-            warning << "(TRestDetectorHits3DReconstructionProcess) event id: " << fInputHitsEvent->GetID()
-                    << ", z: " << z << ", bad frame, too much hits! (" << stripehits.size() << ")" << endl;
+            RESTWarning << "(TRestDetectorHits3DReconstructionProcess) event id: " << fInputHitsEvent->GetID()
+                    << ", z: " << z << ", bad frame, too much hits! (" << stripehits.size() << ")" << RESTendl;
             continue;
         }
 
-        if (fVerboseLevel >= REST_Extreme) {
+        if (fVerboseLevel >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) {
             cout << "stripehits: ";
             for (auto h : stripehits) {
                 cout << h.x1 << "," << h.y1 << "," << h.x2 << "," << h.y2 << "," << h.e << " ";
@@ -374,7 +374,7 @@ TRestEvent* TRestDetectorHits3DReconstructionProcess::ProcessEvent(TRestEvent* i
                 H_PosE.insert(H_PosE.begin(), {(*H_PosE.begin()).first - 1, 0});
                 H_PosE.insert(H_PosE.end(), {(*(H_PosE.end() - 1)).first + 1, 0});
 
-                if (fVerboseLevel >= REST_Extreme) {
+                if (fVerboseLevel >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) {
                     cout << "V: ";
                     for (auto pose : V_PosE) {
                         cout << pose.first << "," << pose.second << " ";
@@ -403,7 +403,7 @@ TRestEvent* TRestDetectorHits3DReconstructionProcess::ProcessEvent(TRestEvent* i
                     }
                 }
 
-                if (fVerboseLevel >= REST_Debug) {
+                if (fVerboseLevel >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
                     cout << i << " z: " << z << " " << Vsegs << " " << Hsegs << " -> "
                          << LogAmbiguity(Vsegs, Hsegs) << endl;
                     cout << endl;

--- a/src/TRestDetectorHitsAnalysisProcess.cxx
+++ b/src/TRestDetectorHitsAnalysisProcess.cxx
@@ -320,7 +320,7 @@ TRestEvent* TRestDetectorHitsAnalysisProcess::ProcessEvent(TRestEvent* inputEven
     SetObservableValue("xySkew", skewXY);
     SetObservableValue("zSkew", skewZ);
 
-    if (GetVerboseLevel() >= REST_Extreme) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) {
         fOutputHitsEvent->PrintEvent(1000);
         GetChar();
     }

--- a/src/TRestDetectorHitsGaussAnalysisProcess.cxx
+++ b/src/TRestDetectorHitsGaussAnalysisProcess.cxx
@@ -167,7 +167,7 @@ TRestEvent* TRestDetectorHitsGaussAnalysisProcess::ProcessEvent(TRestEvent* inpu
     Double_t xy2SigmaGaus = (gausSigmaX * gausSigmaX) + (gausSigmaY * gausSigmaY);
 
     if (hits->GetNumberOfHits() > 30 && xy2SigmaGaus < 0.05)
-        debug << string("Event ID: ") << to_string(fInputHitsEvent->GetID()) << string("||") << endl;
+        RESTDebug << string("Event ID: ") << to_string(fInputHitsEvent->GetID()) << string("||") << RESTendl;
 
     SetObservableValue("xSigmaGaus", gausSigmaX);
     SetObservableValue("ySigmaGaus", gausSigmaY);
@@ -177,10 +177,10 @@ TRestEvent* TRestDetectorHitsGaussAnalysisProcess::ProcessEvent(TRestEvent* inpu
 
     // We transform here fHitsEvent if necessary
 
-    if (GetVerboseLevel() >= REST_Debug) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         fOutputHitsEvent->PrintEvent();
 
-        if (GetVerboseLevel() >= REST_Extreme) GetChar();
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) GetChar();
     }
 
     return fOutputHitsEvent;
@@ -202,7 +202,7 @@ void TRestDetectorHitsGaussAnalysisProcess::PrintMetadata() {
     BeginPrintProcess();
 
     // Print output metadata using, metadata << endl;
-    metadata << "Pitch (mm) : " << fPitch << endl;
+    RESTMetadata << "Pitch (mm) : " << fPitch << RESTendl;
 
     EndPrintProcess();
 }

--- a/src/TRestDetectorHitsNormalizationProcess.cxx
+++ b/src/TRestDetectorHitsNormalizationProcess.cxx
@@ -82,7 +82,7 @@ TRestEvent* TRestDetectorHitsNormalizationProcess::ProcessEvent(TRestEvent* inpu
                                  fHitsInputEvent->GetZ(hit), fHitsInputEvent->GetEnergy(hit) * fFactor,
                                  fHitsInputEvent->GetTime(hit), fHitsInputEvent->GetType(hit));
 
-    if (this->GetVerboseLevel() >= REST_Debug) {
+    if (this->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "TRestDetectorHitsNormalizationProcess. Hits added : " << fHitsOutputEvent->GetNumberOfHits()
              << endl;
         cout << "TRestDetectorHitsNormalizationProcess. Hits total energy : " << fHitsOutputEvent->GetEnergy()

--- a/src/TRestDetectorHitsReductionProcess.cxx
+++ b/src/TRestDetectorHitsReductionProcess.cxx
@@ -80,7 +80,7 @@ TRestEvent* TRestDetectorHitsReductionProcess::ProcessEvent(TRestEvent* inputEve
 
     Int_t finalHits = fOutputHitsEvent->GetNumberOfHits();
 
-    if (this->GetVerboseLevel() == REST_Debug) {
+    if (this->GetVerboseLevel() == TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "TRestDetectorHitsReductionProcess : Initial number of hits : " << initialHits << endl;
         cout << "TRestDetectorHitsReductionProcess : Final number of hits : " << finalHits << endl;
     }

--- a/src/TRestDetectorHitsRotateAndTranslateProcess.cxx
+++ b/src/TRestDetectorHitsRotateAndTranslateProcess.cxx
@@ -99,7 +99,7 @@ TRestEvent* TRestDetectorHitsRotateAndTranslateProcess::ProcessEvent(TRestEvent*
 
     if (fOutputHitsEvent->GetNumberOfHits() == 0) return nullptr;
 
-    debug << "Number of hits rotated: " << fInputHitsEvent->GetNumberOfHits() << endl;
+    RESTDebug << "Number of hits rotated: " << fInputHitsEvent->GetNumberOfHits() << RESTendl;
     return fOutputHitsEvent;
 }
 

--- a/src/TRestDetectorHitsToSignalProcess.cxx
+++ b/src/TRestDetectorHitsToSignalProcess.cxx
@@ -173,9 +173,9 @@ void TRestDetectorHitsToSignalProcess::InitProcess() {
     fGas = GetMetadata<TRestDetectorGas>();
     if (fGas != nullptr) {
 #ifndef USE_Garfield
-        RESTFerr << "A TRestDetectorGas definition was found but REST was not linked to Garfield libraries."
+        RESTError << "A TRestDetectorGas definition was found but REST was not linked to Garfield libraries."
              << RESTendl;
-        RESTFerr << "Please, remove the TRestDetectorGas definition, and add gas parameters inside the process "
+        RESTError << "Please, remove the TRestDetectorGas definition, and add gas parameters inside the process "
                 "TRestDetectorHitsToSignalProcess"
              << RESTendl;
         if (!fGas->GetError()) fGas->SetError("REST was not compiled with Garfield.");

--- a/src/TRestDetectorHitsToSignalProcess.cxx
+++ b/src/TRestDetectorHitsToSignalProcess.cxx
@@ -173,11 +173,11 @@ void TRestDetectorHitsToSignalProcess::InitProcess() {
     fGas = GetMetadata<TRestDetectorGas>();
     if (fGas != nullptr) {
 #ifndef USE_Garfield
-        ferr << "A TRestDetectorGas definition was found but REST was not linked to Garfield libraries."
-             << endl;
-        ferr << "Please, remove the TRestDetectorGas definition, and add gas parameters inside the process "
+        RESTFerr << "A TRestDetectorGas definition was found but REST was not linked to Garfield libraries."
+             << RESTendl;
+        RESTFerr << "Please, remove the TRestDetectorGas definition, and add gas parameters inside the process "
                 "TRestDetectorHitsToSignalProcess"
-             << endl;
+             << RESTendl;
         if (!fGas->GetError()) fGas->SetError("REST was not compiled with Garfield.");
         if (!this->GetError()) this->SetError("Attempt to use TRestDetectorGas without Garfield");
 #endif
@@ -210,7 +210,7 @@ TRestEvent* TRestDetectorHitsToSignalProcess::ProcessEvent(TRestEvent* inputEven
 
     if (!fReadout) return nullptr;
 
-    if (GetVerboseLevel() >= REST_Debug) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "Number of hits : " << fHitsEvent->GetNumberOfHits() << endl;
         cout << "--------------------------" << endl;
     }
@@ -221,7 +221,7 @@ TRestEvent* TRestDetectorHitsToSignalProcess::ProcessEvent(TRestEvent* inputEven
         Double_t z = fHitsEvent->GetZ(hit);
         Double_t t = fHitsEvent->GetTime(hit);
 
-        if (GetVerboseLevel() >= REST_Extreme && hit < 20)
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme && hit < 20)
             cout << "Hit : " << hit << " x : " << x << " y : " << y << " z : " << z << " t : " << t << endl;
 
         Int_t planeId = -1;
@@ -239,20 +239,20 @@ TRestEvent* TRestDetectorHitsToSignalProcess::ProcessEvent(TRestEvent* inputEven
 
                 Double_t time = plane->GetDistanceTo(x, y, z) / fDriftVelocity + t;
 
-                if (GetVerboseLevel() >= REST_Debug && hit < 20)
+                if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug && hit < 20)
                     cout << "Module : " << moduleId << " Channel : " << channelId << " daq ID : " << daqId
                          << endl;
 
-                if (GetVerboseLevel() >= REST_Debug && hit < 20)
+                if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug && hit < 20)
                     cout << "Energy : " << energy << " time : " << time << endl;
 
-                if (GetVerboseLevel() >= REST_Extreme && hit < 20)
+                if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme && hit < 20)
                     printf(
                         " TRestDetectorHitsToSignalProcess: x %lf y %lf z %lf energy %lf t %lf "
                         "fDriftVelocity %lf fSampling %lf time %lf\n",
                         x, y, z, energy, t, fDriftVelocity, fSampling, time);
 
-                if (GetVerboseLevel() >= REST_Extreme)
+                if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme)
                     cout << "Drift velocity : " << fDriftVelocity << " mm/us" << endl;
 
                 time = ((Int_t)(time / fSampling)) * fSampling;  // now time is in unit "us", but dispersed
@@ -260,16 +260,16 @@ TRestEvent* TRestDetectorHitsToSignalProcess::ProcessEvent(TRestEvent* inputEven
                 fSignalEvent->AddChargeToSignal(daqId, time, energy);
 
             } else {
-                if (GetVerboseLevel() >= REST_Debug)
-                    debug << "TRestDetectorHitsToSignalProcess. Readout channel not find for position (" << x
-                          << ", " << y << ", " << z << ")!" << endl;
+                if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
+                    RESTDebug << "TRestDetectorHitsToSignalProcess. Readout channel not find for position (" << x
+                          << ", " << y << ", " << z << ")!" << RESTendl;
             }
         }
     }
 
     fSignalEvent->SortSignals();
 
-    if (GetVerboseLevel() >= REST_Debug) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "TRestDetectorHitsToSignalProcess : Number of signals added : "
              << fSignalEvent->GetNumberOfSignals() << endl;
         cout << "TRestDetectorHitsToSignalProcess : Total signals integral : " << fSignalEvent->GetIntegral()

--- a/src/TRestDetectorPositionMappingProcess.cxx
+++ b/src/TRestDetectorPositionMappingProcess.cxx
@@ -43,7 +43,7 @@ void TRestDetectorPositionMappingProcess::InitProcess() {
     fGas = GetMetadata<TRestDetectorGas>();
     if (fReadout == nullptr) {
         if (fCreateGainMap) {
-            RESTFerr << "You must set a TRestDetectorReadout metadata object to create gain map!" << RESTendl;
+            RESTError << "You must set a TRestDetectorReadout metadata object to create gain map!" << RESTendl;
             abort();
         }
     } else {
@@ -57,7 +57,7 @@ void TRestDetectorPositionMappingProcess::InitProcess() {
 
     if (fApplyGainCorrection) {
         if (fCalib == nullptr || fCalib->f2DGainMapping == nullptr) {
-            RESTFerr << "You must set a TRestDetectorGainMap metadata object to apply gain correction!" << RESTendl;
+            RESTError << "You must set a TRestDetectorGainMap metadata object to apply gain correction!" << RESTendl;
             abort();
         }
     }
@@ -190,7 +190,7 @@ void TRestDetectorPositionMappingProcess::InitFromConfigFile() {
         fApplyGainCorrection = true;
         fSingleThreadOnly = false;
     } else {
-        RESTFerr << "illegal mode definition! supported: create, apply" << RESTendl;
+        RESTError << "illegal mode definition! supported: create, apply" << RESTendl;
         abort();
     }
 

--- a/src/TRestDetectorPositionMappingProcess.cxx
+++ b/src/TRestDetectorPositionMappingProcess.cxx
@@ -43,7 +43,7 @@ void TRestDetectorPositionMappingProcess::InitProcess() {
     fGas = GetMetadata<TRestDetectorGas>();
     if (fReadout == nullptr) {
         if (fCreateGainMap) {
-            ferr << "You must set a TRestDetectorReadout metadata object to create gain map!" << endl;
+            RESTFerr << "You must set a TRestDetectorReadout metadata object to create gain map!" << RESTendl;
             abort();
         }
     } else {
@@ -57,7 +57,7 @@ void TRestDetectorPositionMappingProcess::InitProcess() {
 
     if (fApplyGainCorrection) {
         if (fCalib == nullptr || fCalib->f2DGainMapping == nullptr) {
-            ferr << "You must set a TRestDetectorGainMap metadata object to apply gain correction!" << endl;
+            RESTFerr << "You must set a TRestDetectorGainMap metadata object to apply gain correction!" << RESTendl;
             abort();
         }
     }
@@ -190,7 +190,7 @@ void TRestDetectorPositionMappingProcess::InitFromConfigFile() {
         fApplyGainCorrection = true;
         fSingleThreadOnly = false;
     } else {
-        ferr << "illegal mode definition! supported: create, apply" << endl;
+        RESTFerr << "illegal mode definition! supported: create, apply" << RESTendl;
         abort();
     }
 

--- a/src/TRestDetectorReadout.cxx
+++ b/src/TRestDetectorReadout.cxx
@@ -421,10 +421,10 @@ TRestDetectorReadoutPlane* TRestDetectorReadout::GetReadoutPlane(int p) {
     if (p < fNReadoutPlanes)
         return &fReadoutPlanes[p];
     else {
-        warning << "TRestDetectorReadout::GetReadoutPlane." << endl;
-        warning << "Readout plane index exceeded." << endl;
-        warning << "Index requested : " << p << endl;
-        warning << "Number of readout planes defined : " << fNReadoutPlanes << endl;
+        RESTWarning << "TRestDetectorReadout::GetReadoutPlane." << RESTendl;
+        RESTWarning << "Readout plane index exceeded." << RESTendl;
+        RESTWarning << "Index requested : " << p << RESTendl;
+        RESTWarning << "Number of readout planes defined : " << fNReadoutPlanes << RESTendl;
     }
 
     return nullptr;
@@ -448,7 +448,7 @@ void TRestDetectorReadout::InitFromConfigFile() {
 #pragma region ParseModuledefinition
     TiXmlElement* moduleDefinition = GetElement("readoutModule");
     while (moduleDefinition != nullptr) {
-        if (GetVerboseLevel() >= REST_Debug) {
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
             cout << "------module-----------------" << endl;
             cout << moduleDefinition << endl;
             cout << "-----------------------------" << endl;
@@ -486,9 +486,9 @@ void TRestDetectorReadout::InitFromConfigFile() {
             Int_t mid = GetModuleDefinitionId(modName);
 
             if (mid == -1) {
-                ferr << "TRestDetectorReadout at <addReadoutModule>. Module name " << modName << " not found!"
-                     << endl;
-                ferr << "Please, check spelling" << endl;
+                RESTFerr << "TRestDetectorReadout at <addReadoutModule>. Module name " << modName << " not found!"
+                     << RESTendl;
+                RESTFerr << "Please, check spelling" << RESTendl;
                 exit(1);
             }
 
@@ -508,15 +508,15 @@ void TRestDetectorReadout::InitFromConfigFile() {
                 fDecoding = true;
 
             if (fDecoding && !TRestTools::fileExists(decodingFile.c_str())) {
-                warning << "The decoding file does not exist!" << endl;
-                warning << "--------------------------------" << endl;
-                warning << "File : " << decodingFile << endl;
-                warning << "Default decoding will be used. readoutChannel=daqChannel" << endl;
-                warning << "To avoid this message and use the default decoding define : "
+                RESTWarning << "The decoding file does not exist!" << RESTendl;
+                RESTWarning << "--------------------------------" << RESTendl;
+                RESTWarning << "File : " << decodingFile << RESTendl;
+                RESTWarning << "Default decoding will be used. readoutChannel=daqChannel" << RESTendl;
+                RESTWarning << "To avoid this message and use the default decoding define : "
                            "decodingFile=\"\""
-                        << endl;
-                warning << "--------------------------------" << endl;
-                warning << "Press a KEY to continue..." << endl;
+                        << RESTendl;
+                RESTWarning << "--------------------------------" << RESTendl;
+                RESTWarning << "Press a KEY to continue..." << RESTendl;
                 getchar();
                 fDecoding = false;
                 RESTREADOUT_DECODINGFILE_ERROR = true;
@@ -530,8 +530,8 @@ void TRestDetectorReadout::InitFromConfigFile() {
                 Int_t daq, readout;
                 while (!feof(f)) {
                     if (fscanf(f, "%d\t%d\n", &daq, &readout) <= 0) {
-                        ferr << "TRestDetectorReadout::InitFromConfigFile. Problem reading decoding" << endl;
-                        ferr << "This error might need support at REST forum" << endl;
+                        RESTFerr << "TRestDetectorReadout::InitFromConfigFile. Problem reading decoding" << RESTendl;
+                        RESTFerr << "This error might need support at REST forum" << RESTendl;
                         exit(-1);
                     }
                     // we skip blank daq channels if readout id is <0
@@ -544,7 +544,7 @@ void TRestDetectorReadout::InitFromConfigFile() {
                 fclose(f);
             }
 
-            if (GetVerboseLevel() >= REST_Debug) {
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
                 cout << "------module-----------------" << endl;
                 cout << moduleDefinition << endl;
                 cout << "-----------------------------" << endl;
@@ -552,9 +552,9 @@ void TRestDetectorReadout::InitFromConfigFile() {
             }
 
             if (fDecoding && (unsigned int)fModuleDefinitions[mid].GetNumberOfChannels() != rChannel.size()) {
-                ferr << "TRestDetectorReadout."
+                RESTFerr << "TRestDetectorReadout."
                      << " The number of channels defined in the readout is not the same"
-                     << " as the number of channels found in the decoding." << endl;
+                     << " as the number of channels found in the decoding." << RESTendl;
                 exit(1);
             }
 
@@ -608,7 +608,7 @@ void TRestDetectorReadout::InitFromConfigFile() {
 TRestDetectorReadoutModule* TRestDetectorReadout::ParseModuleDefinition(TiXmlElement* moduleDefinition) {
     TRestDetectorReadoutModule* mod = new TRestDetectorReadoutModule();
     TRestDetectorReadoutModule& module = *mod;
-    if (GetVerboseLevel() >= REST_Warning) module.EnableWarnings();
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Warning) module.EnableWarnings();
 
     module.SetName(GetFieldValue("name", moduleDefinition));
     module.SetSize(StringTo2DVector(GetFieldValue("size", moduleDefinition)));
@@ -648,9 +648,9 @@ TRestDetectorReadoutModule* TRestDetectorReadout::ParseModuleDefinition(TiXmlEle
         }
 
         if (pixelIDVector.size() > 0 && pixelIDVector.size() != pixelVector.size()) {
-            ferr << "pixel id definition may be wrong! It must be coherent and starts from 0. Check your "
+            RESTFerr << "pixel id definition may be wrong! It must be coherent and starts from 0. Check your "
                     "readout module definition!"
-                 << endl;
+                 << RESTendl;
             exit(0);
         }
 
@@ -666,9 +666,9 @@ TRestDetectorReadoutModule* TRestDetectorReadout::ParseModuleDefinition(TiXmlEle
         }
 
         if (channel.GetNumberOfPixels() != pixelVector.size()) {
-            ferr << "pixel id definition may be wrong! check your "
+            RESTFerr << "pixel id definition may be wrong! check your "
                     "readout module definition!"
-                 << endl;
+                 << RESTendl;
             exit(0);
         }
 #pragma endregion
@@ -678,11 +678,11 @@ TRestDetectorReadoutModule* TRestDetectorReadout::ParseModuleDefinition(TiXmlEle
     }
 
     if (channelIDVector.size() > 0 && channelIDVector.size() != channelVector.size()) {
-        ferr << "TRestDetectorReadout::ParseModuleDefinition. Channel id definition may be wrong!"
-             << "check your readout module definition!" << endl;
-        ferr << " " << endl;
-        ferr << "channelIDVector size : " << channelIDVector.size() << endl;
-        ferr << "channel vector size : " << channelVector.size() << endl;
+        RESTFerr << "TRestDetectorReadout::ParseModuleDefinition. Channel id definition may be wrong!"
+             << "check your readout module definition!" << RESTendl;
+        RESTFerr << " " << RESTendl;
+        RESTFerr << "channelIDVector size : " << channelIDVector.size() << RESTendl;
+        RESTFerr << "channel vector size : " << channelVector.size() << RESTendl;
 
         exit(0);
     }
@@ -699,11 +699,11 @@ TRestDetectorReadoutModule* TRestDetectorReadout::ParseModuleDefinition(TiXmlEle
     }
 
     if (module.GetNumberOfChannels() != channelVector.size()) {
-        ferr << "TRestDetectorReadout::ParseModuleDefinition. Channel id definition may be wrong!"
-             << "check your readout module definition!" << endl;
-        ferr << " " << endl;
-        ferr << "Module number of channels : " << module.GetNumberOfChannels() << endl;
-        ferr << "channel vector size : " << channelVector.size() << endl;
+        RESTFerr << "TRestDetectorReadout::ParseModuleDefinition. Channel id definition may be wrong!"
+             << "check your readout module definition!" << RESTendl;
+        RESTFerr << " " << RESTendl;
+        RESTFerr << "Module number of channels : " << module.GetNumberOfChannels() << RESTendl;
+        RESTFerr << "channel vector size : " << channelVector.size() << RESTendl;
 
         exit(0);
     }
@@ -782,8 +782,8 @@ Int_t TRestDetectorReadout::GetHitsDaqChannel(const TVector3& hitpos, Int_t& pla
 Int_t TRestDetectorReadout::GetHitsDaqChannelAtReadoutPlane(const TVector3& hitpos, Int_t& moduleID,
                                                             Int_t& channelID, Int_t planeId) {
     if (planeId > GetNumberOfReadoutPlanes()) {
-        warning << "TRestDetectorReadout. Fail trying to retrieve planeId : " << planeId << endl;
-        warning << "Number of readout planes: " << GetNumberOfReadoutPlanes() << endl;
+        RESTWarning << "TRestDetectorReadout. Fail trying to retrieve planeId : " << planeId << RESTendl;
+        RESTWarning << "Number of readout planes: " << GetNumberOfReadoutPlanes() << RESTendl;
         return -1;
     }
 
@@ -848,15 +848,15 @@ void TRestDetectorReadout::PrintMetadata(Int_t DetailLevel) {
     if (DetailLevel >= 0) {
         TRestMetadata::PrintMetadata();
 
-        metadata << "Number of readout planes : " << fNReadoutPlanes << endl;
-        metadata << "Decoding was defined : ";
+        RESTMetadata << "Number of readout planes : " << fNReadoutPlanes << RESTendl;
+        RESTMetadata << "Decoding was defined : ";
         if (fDecoding)
-            metadata << "YES" << endl;
+            RESTMetadata << "YES" << RESTendl;
         else
-            metadata << "NO" << endl;
-        metadata << "-----------------------------------" << endl;
+            RESTMetadata << "NO" << RESTendl;
+        RESTMetadata << "-----------------------------------" << RESTendl;
         for (int p = 0; p < GetNumberOfReadoutPlanes(); p++) fReadoutPlanes[p].Print(DetailLevel - 1);
-        metadata << "****************************************" << endl;
+        RESTMetadata << "****************************************" << RESTendl;
         cout << endl;
     }
 }

--- a/src/TRestDetectorReadout.cxx
+++ b/src/TRestDetectorReadout.cxx
@@ -486,9 +486,9 @@ void TRestDetectorReadout::InitFromConfigFile() {
             Int_t mid = GetModuleDefinitionId(modName);
 
             if (mid == -1) {
-                RESTFerr << "TRestDetectorReadout at <addReadoutModule>. Module name " << modName << " not found!"
+                RESTError << "TRestDetectorReadout at <addReadoutModule>. Module name " << modName << " not found!"
                      << RESTendl;
-                RESTFerr << "Please, check spelling" << RESTendl;
+                RESTError << "Please, check spelling" << RESTendl;
                 exit(1);
             }
 
@@ -530,8 +530,8 @@ void TRestDetectorReadout::InitFromConfigFile() {
                 Int_t daq, readout;
                 while (!feof(f)) {
                     if (fscanf(f, "%d\t%d\n", &daq, &readout) <= 0) {
-                        RESTFerr << "TRestDetectorReadout::InitFromConfigFile. Problem reading decoding" << RESTendl;
-                        RESTFerr << "This error might need support at REST forum" << RESTendl;
+                        RESTError << "TRestDetectorReadout::InitFromConfigFile. Problem reading decoding" << RESTendl;
+                        RESTError << "This error might need support at REST forum" << RESTendl;
                         exit(-1);
                     }
                     // we skip blank daq channels if readout id is <0
@@ -552,7 +552,7 @@ void TRestDetectorReadout::InitFromConfigFile() {
             }
 
             if (fDecoding && (unsigned int)fModuleDefinitions[mid].GetNumberOfChannels() != rChannel.size()) {
-                RESTFerr << "TRestDetectorReadout."
+                RESTError << "TRestDetectorReadout."
                      << " The number of channels defined in the readout is not the same"
                      << " as the number of channels found in the decoding." << RESTendl;
                 exit(1);
@@ -648,7 +648,7 @@ TRestDetectorReadoutModule* TRestDetectorReadout::ParseModuleDefinition(TiXmlEle
         }
 
         if (pixelIDVector.size() > 0 && pixelIDVector.size() != pixelVector.size()) {
-            RESTFerr << "pixel id definition may be wrong! It must be coherent and starts from 0. Check your "
+            RESTError << "pixel id definition may be wrong! It must be coherent and starts from 0. Check your "
                     "readout module definition!"
                  << RESTendl;
             exit(0);
@@ -666,7 +666,7 @@ TRestDetectorReadoutModule* TRestDetectorReadout::ParseModuleDefinition(TiXmlEle
         }
 
         if (channel.GetNumberOfPixels() != pixelVector.size()) {
-            RESTFerr << "pixel id definition may be wrong! check your "
+            RESTError << "pixel id definition may be wrong! check your "
                     "readout module definition!"
                  << RESTendl;
             exit(0);
@@ -678,11 +678,11 @@ TRestDetectorReadoutModule* TRestDetectorReadout::ParseModuleDefinition(TiXmlEle
     }
 
     if (channelIDVector.size() > 0 && channelIDVector.size() != channelVector.size()) {
-        RESTFerr << "TRestDetectorReadout::ParseModuleDefinition. Channel id definition may be wrong!"
+        RESTError << "TRestDetectorReadout::ParseModuleDefinition. Channel id definition may be wrong!"
              << "check your readout module definition!" << RESTendl;
-        RESTFerr << " " << RESTendl;
-        RESTFerr << "channelIDVector size : " << channelIDVector.size() << RESTendl;
-        RESTFerr << "channel vector size : " << channelVector.size() << RESTendl;
+        RESTError << " " << RESTendl;
+        RESTError << "channelIDVector size : " << channelIDVector.size() << RESTendl;
+        RESTError << "channel vector size : " << channelVector.size() << RESTendl;
 
         exit(0);
     }
@@ -699,11 +699,11 @@ TRestDetectorReadoutModule* TRestDetectorReadout::ParseModuleDefinition(TiXmlEle
     }
 
     if (module.GetNumberOfChannels() != channelVector.size()) {
-        RESTFerr << "TRestDetectorReadout::ParseModuleDefinition. Channel id definition may be wrong!"
+        RESTError << "TRestDetectorReadout::ParseModuleDefinition. Channel id definition may be wrong!"
              << "check your readout module definition!" << RESTendl;
-        RESTFerr << " " << RESTendl;
-        RESTFerr << "Module number of channels : " << module.GetNumberOfChannels() << RESTendl;
-        RESTFerr << "channel vector size : " << channelVector.size() << RESTendl;
+        RESTError << " " << RESTendl;
+        RESTError << "Module number of channels : " << module.GetNumberOfChannels() << RESTendl;
+        RESTError << "channel vector size : " << channelVector.size() << RESTendl;
 
         exit(0);
     }

--- a/src/TRestDetectorReadoutChannel.cxx
+++ b/src/TRestDetectorReadoutChannel.cxx
@@ -77,7 +77,7 @@ Int_t TRestDetectorReadoutChannel::isInside(Double_t x, Double_t y) {
 ///
 void TRestDetectorReadoutChannel::Print(int DetailLevel) {
     if (DetailLevel >= 0) {
-        metadata << "++++ Channel : " << GetChannelId() << " Daq channel : " << GetDaqID() << endl;
+        RESTMetadata << "++++ Channel : " << GetChannelId() << " Daq channel : " << GetDaqID() << RESTendl;
 
         string typestr;
         if (GetType() == Channel_NoType)
@@ -95,8 +95,8 @@ void TRestDetectorReadoutChannel::Print(int DetailLevel) {
         else if (GetType() == Channel_W)
             typestr = "W";
 
-        metadata << " Total pixels : " << GetNumberOfPixels() << " Channel type : " << typestr << endl;
-        metadata << "+++++++++++++++++++++++++++++++++++++++++++++++++" << endl;
+        RESTMetadata << " Total pixels : " << GetNumberOfPixels() << " Channel type : " << typestr << RESTendl;
+        RESTMetadata << "+++++++++++++++++++++++++++++++++++++++++++++++++" << RESTendl;
 
         if (DetailLevel - 1 >= 0)
             for (int n = 0; n < GetNumberOfPixels(); n++) {

--- a/src/TRestDetectorReadoutModule.cxx
+++ b/src/TRestDetectorReadoutModule.cxx
@@ -150,10 +150,10 @@ void TRestDetectorReadoutModule::DoReadoutMapping(Int_t nodes) {
 
                 Int_t tempCh = fMapping.GetChannelByNode(nodeX, nodeY);
                 Int_t tempPix = fMapping.GetPixelByNode(nodeX, nodeY);
-                warning << "Already associated channel : " << tempCh << " pixel : " << tempPix << endl;
+                RESTWarning << "Already associated channel : " << tempCh << " pixel : " << tempPix << RESTendl;
                 Double_t xP = this->GetChannel(tempCh)->GetPixel(tempPix)->GetCenter().X();
                 Double_t yP = this->GetChannel(tempCh)->GetPixel(tempPix)->GetCenter().Y();
-                warning << "Pixel coordinates : ( " << xP << " , " << yP << " ) " << endl;
+                RESTWarning << "Pixel coordinates : ( " << xP << " , " << yP << " ) " << RESTendl;
                 cout << endl;
 
                 cout << "Increasing the number of mapping of nodes may solve this issue." << endl;
@@ -291,8 +291,8 @@ Int_t TRestDetectorReadoutModule::FindChannel(Double_t absX, Double_t absY) {
         pixel = fMapping.GetPixelByNode(nodeX, nodeY);
 
         if (count > totalNodes / 10) {
-            warning << "TRestDetectorReadoutModule. I did not find any channel for hit position (" << x << ","
-                    << y << ") in internal module coordinates" << endl;
+            RESTWarning << "TRestDetectorReadoutModule. I did not find any channel for hit position (" << x << ","
+                    << y << ") in internal module coordinates" << RESTendl;
 
             for (int ch = 0; ch < GetNumberOfChannels(); ch++)
                 for (int px = 0; px < GetChannel(ch)->GetNumberOfPixels(); px++)
@@ -535,15 +535,15 @@ void TRestDetectorReadoutModule::Draw() {}
 ///
 void TRestDetectorReadoutModule::Print(Int_t DetailLevel) {
     if (DetailLevel >= 0) {
-        metadata << "-- Readout module : " << GetModuleID() << endl;
-        metadata << "----------------------------------------------------------------" << endl;
-        metadata << "-- Origin position : X = " << fModuleOriginX << " mm "
-                 << " Y : " << fModuleOriginY << " mm" << endl;
-        metadata << "-- Size : X = " << fModuleSizeX << " Y : " << fModuleSizeY << endl;
-        metadata << "-- Rotation : " << fModuleRotation << " degrees" << endl;
-        metadata << "-- Total channels : " << GetNumberOfChannels() << endl;
-        metadata << "-- Tolerance : " << fTolerance << endl;
-        metadata << "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++" << endl;
+        RESTMetadata << "-- Readout module : " << GetModuleID() << RESTendl;
+        RESTMetadata << "----------------------------------------------------------------" << RESTendl;
+        RESTMetadata << "-- Origin position : X = " << fModuleOriginX << " mm "
+                 << " Y : " << fModuleOriginY << " mm" << RESTendl;
+        RESTMetadata << "-- Size : X = " << fModuleSizeX << " Y : " << fModuleSizeY << RESTendl;
+        RESTMetadata << "-- Rotation : " << fModuleRotation << " degrees" << RESTendl;
+        RESTMetadata << "-- Total channels : " << GetNumberOfChannels() << RESTendl;
+        RESTMetadata << "-- Tolerance : " << fTolerance << RESTendl;
+        RESTMetadata << "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++" << RESTendl;
 
         for (int n = 0; n < GetNumberOfChannels(); n++) fReadoutChannel[n].Print(DetailLevel - 1);
     }

--- a/src/TRestDetectorReadoutPixel.cxx
+++ b/src/TRestDetectorReadoutPixel.cxx
@@ -153,12 +153,12 @@ TVector2 TRestDetectorReadoutPixel::TransformToPixelCoordinates(TVector2 p) {
 /// \brief Prints on screen the pixel details, origin, size, rotation
 ///
 void TRestDetectorReadoutPixel::Print() {
-    metadata << "    ## Pixel  position : (" << GetOriginX() << "," << GetOriginY() << ") mm size : ("
-             << GetSizeX() << "," << GetSizeY() << ") mm" << endl;
-    metadata << "       rotation : " << fRotation << " degrees"
+    RESTMetadata << "    ## Pixel  position : (" << GetOriginX() << "," << GetOriginY() << ") mm size : ("
+             << GetSizeX() << "," << GetSizeY() << ") mm" << RESTendl;
+    RESTMetadata << "       rotation : " << fRotation << " degrees"
              << " type : ";
     if (fTriangle)
-        metadata << "triangle" << endl;
+        RESTMetadata << "triangle" << RESTendl;
     else
-        metadata << "rectangle" << endl;
+        RESTMetadata << "rectangle" << RESTendl;
 }

--- a/src/TRestDetectorReadoutPlane.cxx
+++ b/src/TRestDetectorReadoutPlane.cxx
@@ -363,19 +363,19 @@ Int_t TRestDetectorReadoutPlane::GetModuleIDFromPosition(TVector3 pos) {
 ///
 void TRestDetectorReadoutPlane::Print(Int_t DetailLevel) {
     if (DetailLevel >= 0) {
-        metadata << "-- Readout plane : " << GetID() << endl;
-        metadata << "----------------------------------------------------------------" << endl;
-        metadata << "-- Position : X = " << fPosition.X() << " mm, "
-                 << " Y : " << fPosition.Y() << " mm, Z : " << fPosition.Z() << " mm" << endl;
-        metadata << "-- Vector : X = " << fPlaneVector.X() << " mm, "
-                 << " Y : " << fPlaneVector.Y() << " mm, Z : " << fPlaneVector.Z() << " mm" << endl;
-        metadata << "-- Cathode Position : X = " << fCathodePosition.X() << " mm, "
-                 << " Y : " << fCathodePosition.Y() << " mm, Z : " << fCathodePosition.Z() << " mm" << endl;
-        metadata << "-- Total drift distance : " << fTotalDriftDistance << " mm" << endl;
-        metadata << "-- Charge collection : " << fChargeCollection << endl;
-        metadata << "-- Total modules : " << GetNumberOfModules() << endl;
-        metadata << "-- Total channels : " << GetNumberOfChannels() << endl;
-        metadata << "----------------------------------------------------------------" << endl;
+        RESTMetadata << "-- Readout plane : " << GetID() << RESTendl;
+        RESTMetadata << "----------------------------------------------------------------" << RESTendl;
+        RESTMetadata << "-- Position : X = " << fPosition.X() << " mm, "
+                 << " Y : " << fPosition.Y() << " mm, Z : " << fPosition.Z() << " mm" << RESTendl;
+        RESTMetadata << "-- Vector : X = " << fPlaneVector.X() << " mm, "
+                 << " Y : " << fPlaneVector.Y() << " mm, Z : " << fPlaneVector.Z() << " mm" << RESTendl;
+        RESTMetadata << "-- Cathode Position : X = " << fCathodePosition.X() << " mm, "
+                 << " Y : " << fCathodePosition.Y() << " mm, Z : " << fCathodePosition.Z() << " mm" << RESTendl;
+        RESTMetadata << "-- Total drift distance : " << fTotalDriftDistance << " mm" << RESTendl;
+        RESTMetadata << "-- Charge collection : " << fChargeCollection << RESTendl;
+        RESTMetadata << "-- Total modules : " << GetNumberOfModules() << RESTendl;
+        RESTMetadata << "-- Total channels : " << GetNumberOfChannels() << RESTendl;
+        RESTMetadata << "----------------------------------------------------------------" << RESTendl;
 
         for (int i = 0; i < GetNumberOfModules(); i++) fReadoutModules[i].Print(DetailLevel - 1);
     }

--- a/src/TRestDetectorSignalChannelActivityProcess.cxx
+++ b/src/TRestDetectorSignalChannelActivityProcess.cxx
@@ -155,8 +155,8 @@ void TRestDetectorSignalChannelActivityProcess::LoadConfig(const string& configF
 void TRestDetectorSignalChannelActivityProcess::InitProcess() {
     fReadout = GetMetadata<TRestDetectorReadout>();
 
-    debug << "TRestDetectorSignalChannelActivityProcess::InitProcess. Readout pointer : " << fReadout << endl;
-    if (GetVerboseLevel() >= REST_Info && fReadout) fReadout->PrintMetadata();
+    RESTDebug << "TRestDetectorSignalChannelActivityProcess::InitProcess. Readout pointer : " << fReadout << RESTendl;
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Info && fReadout) fReadout->PrintMetadata();
 
     if (!fReadOnly) {
         fDaqChannelsHisto = new TH1D("daqChannelActivity", "daqChannelActivity", fDaqHistogramChannels,
@@ -252,7 +252,7 @@ TRestEvent* TRestDetectorSignalChannelActivityProcess::ProcessEvent(TRestEvent* 
         }
     }
 
-    if (GetVerboseLevel() >= REST_Debug) fAnalysisTree->PrintObservables();
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) fAnalysisTree->PrintObservables();
 
     return fSignalEvent;
 }

--- a/src/TRestDetectorSignalToHitsProcess.cxx
+++ b/src/TRestDetectorSignalToHitsProcess.cxx
@@ -176,9 +176,9 @@ void TRestDetectorSignalToHitsProcess::InitProcess() {
     fGas = GetMetadata<TRestDetectorGas>();
     if (fGas != nullptr) {
 #ifndef USE_Garfield
-        RESTFerr << "A TRestDetectorGas definition was found but REST was not linked to Garfield libraries."
+        RESTError << "A TRestDetectorGas definition was found but REST was not linked to Garfield libraries."
              << RESTendl;
-        RESTFerr << "Please, remove the TRestDetectorGas definition, and add gas parameters inside the process "
+        RESTError << "Please, remove the TRestDetectorGas definition, and add gas parameters inside the process "
                 "TRestDetectorSignalToHitsProcess"
              << RESTendl;
         if (!fGas->GetError()) fGas->SetError("REST was not compiled with Garfield.");

--- a/src/TRestDetectorSignalToHitsProcess.cxx
+++ b/src/TRestDetectorSignalToHitsProcess.cxx
@@ -176,11 +176,11 @@ void TRestDetectorSignalToHitsProcess::InitProcess() {
     fGas = GetMetadata<TRestDetectorGas>();
     if (fGas != nullptr) {
 #ifndef USE_Garfield
-        ferr << "A TRestDetectorGas definition was found but REST was not linked to Garfield libraries."
-             << endl;
-        ferr << "Please, remove the TRestDetectorGas definition, and add gas parameters inside the process "
+        RESTFerr << "A TRestDetectorGas definition was found but REST was not linked to Garfield libraries."
+             << RESTendl;
+        RESTFerr << "Please, remove the TRestDetectorGas definition, and add gas parameters inside the process "
                 "TRestDetectorSignalToHitsProcess"
-             << endl;
+             << RESTendl;
         if (!fGas->GetError()) fGas->SetError("REST was not compiled with Garfield.");
         if (!this->GetError()) this->SetError("Attempt to use TRestDetectorGas without Garfield");
 #endif
@@ -218,8 +218,8 @@ TRestEvent* TRestDetectorSignalToHitsProcess::ProcessEvent(TRestEvent* inputEven
     fHitsEvent->SetTimeStamp(fSignalEvent->GetTimeStamp());
     fHitsEvent->SetSubEventTag(fSignalEvent->GetSubEventTag());
 
-    debug << "TRestDetectorSignalToHitsProcess. Event id : " << fHitsEvent->GetID() << endl;
-    if (GetVerboseLevel() >= REST_Extreme) fSignalEvent->PrintEvent();
+    RESTDebug << "TRestDetectorSignalToHitsProcess. Event id : " << fHitsEvent->GetID() << RESTendl;
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) fSignalEvent->PrintEvent();
 
     Int_t numberOfSignals = fSignalEvent->GetNumberOfSignals();
 
@@ -230,7 +230,7 @@ TRestEvent* TRestDetectorSignalToHitsProcess::ProcessEvent(TRestEvent* inputEven
         TRestDetectorSignal* sgnl = fSignalEvent->GetSignal(i);
         Int_t signalID = sgnl->GetSignalID();
 
-        if (GetVerboseLevel() >= REST_Debug)
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
             cout << "Searching readout coordinates for signal ID : " << signalID << endl;
 
         fReadout->GetPlaneModuleChannel(signalID, planeID, readoutModule, readoutChannel);
@@ -267,13 +267,13 @@ TRestEvent* TRestDetectorSignalToHitsProcess::ProcessEvent(TRestEvent* inputEven
             Double_t time = sgnl->GetMaxPeakTime();
             Double_t distanceToPlane = time * fDriftVelocity;
 
-            if (GetVerboseLevel() >= REST_Debug) cout << "Distance to plane : " << distanceToPlane << endl;
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) cout << "Distance to plane : " << distanceToPlane << endl;
 
             Double_t z = zPosition + fieldZDirection * distanceToPlane;
 
             Double_t energy = sgnl->GetMaxPeakValue();
 
-            if (GetVerboseLevel() >= REST_Debug)
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
                 cout << "Adding hit. Time : " << time << " x : " << x << " y : " << y << " z : " << z
                      << " Energy : " << energy << endl;
 
@@ -307,7 +307,7 @@ TRestEvent* TRestDetectorSignalToHitsProcess::ProcessEvent(TRestEvent* inputEven
 
             fHitsEvent->AddHit(x, y, z, energy, 0, type);
 
-            if (GetVerboseLevel() >= REST_Debug) {
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
                 cout << "Distance to plane : " << distanceToPlane << endl;
                 cout << "Adding hit. Time : " << time << " x : " << x << " y : " << y << " z : " << z
                      << " Energy : " << energy << endl;
@@ -331,14 +331,14 @@ TRestEvent* TRestDetectorSignalToHitsProcess::ProcessEvent(TRestEvent* inputEven
 
                 Double_t distanceToPlane = sgnl->GetTime(j) * fDriftVelocity;
 
-                if (GetVerboseLevel() >= REST_Debug) {
+                if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
                     cout << "Time : " << sgnl->GetTime(j) << " Drift velocity : " << fDriftVelocity << endl;
                     cout << "Distance to plane : " << distanceToPlane << endl;
                 }
 
                 Double_t z = zPosition + fieldZDirection * distanceToPlane;
 
-                if (GetVerboseLevel() >= REST_Debug)
+                if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
                     cout << "Adding hit. Time : " << sgnl->GetTime(j) << " x : " << x << " y : " << y
                          << " z : " << z << endl;
 
@@ -362,15 +362,15 @@ TRestEvent* TRestDetectorSignalToHitsProcess::ProcessEvent(TRestEvent* inputEven
                 Double_t time = index * fIntWindow + fIntWindow / 2.;
                 Double_t energy = pair.second / pair.first;
                 if (energy < fThreshold) continue;
-                debug << "TimeBin " << index << " Time " << time << " Charge: " << energy
-                      << " Thr: " << (fThreshold) << endl;
+                RESTDebug << "TimeBin " << index << " Time " << time << " Charge: " << energy
+                      << " Thr: " << (fThreshold) << RESTendl;
                 Double_t distanceToPlane = time * fDriftVelocity;
                 Double_t z = zPosition + fieldZDirection * distanceToPlane;
 
-                debug << "Time : " << time << " Drift velocity : " << fDriftVelocity
-                      << "\nDistance to plane : " << distanceToPlane << endl;
-                debug << "Adding hit. Time : " << time << " x : " << x << " y : " << y << " z : " << z
-                      << " type " << type << endl;
+                RESTDebug << "Time : " << time << " Drift velocity : " << fDriftVelocity
+                      << "\nDistance to plane : " << distanceToPlane << RESTendl;
+                RESTDebug << "Adding hit. Time : " << time << " x : " << x << " y : " << y << " z : " << z
+                      << " type " << type << RESTendl;
 
                 fHitsEvent->AddHit(x, y, z, energy, 0, type);
             }
@@ -380,12 +380,12 @@ TRestEvent* TRestDetectorSignalToHitsProcess::ProcessEvent(TRestEvent* inputEven
         }
     }
 
-    debug << "TRestDetectorSignalToHitsProcess. Hits added : " << fHitsEvent->GetNumberOfHits() << endl;
-    debug << "TRestDetectorSignalToHitsProcess. Hits total energy : " << fHitsEvent->GetEnergy() << endl;
+    RESTDebug << "TRestDetectorSignalToHitsProcess. Hits added : " << fHitsEvent->GetNumberOfHits() << RESTendl;
+    RESTDebug << "TRestDetectorSignalToHitsProcess. Hits total energy : " << fHitsEvent->GetEnergy() << RESTendl;
 
-    if (this->GetVerboseLevel() == REST_Debug) {
+    if (this->GetVerboseLevel() == TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         fHitsEvent->PrintEvent(30);
-    } else if (this->GetVerboseLevel() == REST_Extreme) {
+    } else if (this->GetVerboseLevel() == TRestStringOutput::REST_Verbose_Level::REST_Extreme) {
         fHitsEvent->PrintEvent(-1);
     }
 

--- a/src/TRestDetectorSignalViewerProcess.cxx
+++ b/src/TRestDetectorSignalViewerProcess.cxx
@@ -95,9 +95,9 @@ TRestEvent* TRestDetectorSignalViewerProcess::ProcessEvent(TRestEvent* inputEven
         pad2->Draw();
         fCanvas->Update();
 
-        RESTFout.setborder("");
-        RESTFout.setorientation(TRestStringOutput::REST_Display_Orientation::kLeft);
-        RESTFout << "Press Enter to continue\nPress Esc to stop viewing\nPress n/p to "
+        RESTcout.setborder("");
+        RESTcout.setorientation(TRestStringOutput::REST_Display_Orientation::kLeft);
+        RESTcout << "Press Enter to continue\nPress Esc to stop viewing\nPress n/p to "
                 "switch signals"
              << RESTendl;
 

--- a/src/TRestDetectorSignalViewerProcess.cxx
+++ b/src/TRestDetectorSignalViewerProcess.cxx
@@ -81,7 +81,7 @@ TRestEvent* TRestDetectorSignalViewerProcess::ProcessEvent(TRestEvent* inputEven
     if (eveCounter >= fDrawRefresh) {
         eveCounter = 0;
         sgnCounter = 0;
-        if (GetVerboseLevel() >= REST_Debug) {
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
             GetAnalysisTree()->PrintObservables();
         }
         for (auto object : fDrawingObjects) {
@@ -95,11 +95,11 @@ TRestEvent* TRestDetectorSignalViewerProcess::ProcessEvent(TRestEvent* inputEven
         pad2->Draw();
         fCanvas->Update();
 
-        fout.setborder("");
-        fout.setorientation(1);
-        fout << "Press Enter to continue\nPress Esc to stop viewing\nPress n/p to "
+        RESTFout.setborder("");
+        RESTFout.setorientation(TRestStringOutput::REST_Display_Orientation::kLeft);
+        RESTFout << "Press Enter to continue\nPress Esc to stop viewing\nPress n/p to "
                 "switch signals"
-             << endl;
+             << RESTendl;
 
         while (true) {
             int a = GetChar("");
@@ -121,7 +121,7 @@ TRestEvent* TRestDetectorSignalViewerProcess::ProcessEvent(TRestEvent* inputEven
                     pad2->Draw();
                     fCanvas->Update();
                 } else {
-                    warning << "cannot plot signal with id " << sgnCounter << endl;
+                    RESTWarning << "cannot plot signal with id " << sgnCounter << RESTendl;
                 }
             } else if (a == 112 || a == 80)  // p
             {
@@ -132,7 +132,7 @@ TRestEvent* TRestDetectorSignalViewerProcess::ProcessEvent(TRestEvent* inputEven
                     pad2->Draw();
                     fCanvas->Update();
                 } else {
-                    warning << "cannot plot signal with id " << sgnCounter << endl;
+                    RESTWarning << "cannot plot signal with id " << sgnCounter << RESTendl;
                 }
             }
             while (getchar() != '\n')

--- a/src/TRestDetectorSingleChannelAnalysisProcess.cxx
+++ b/src/TRestDetectorSingleChannelAnalysisProcess.cxx
@@ -66,20 +66,20 @@ void TRestDetectorSingleChannelAnalysisProcess::InitProcess() {
         if (fCalib != nullptr) {
             for (auto iter = fChannelGain.begin(); iter != fChannelGain.end(); iter++) {
                 if (fCalib->fChannelGain.count(iter->first) == 0) {
-                    RESTFerr << "in consistent gain mapping and readout definition!" << RESTendl;
-                    RESTFerr << "channel: " << iter->first << " not fount in mapping file!" << RESTendl;
+                    RESTError << "in consistent gain mapping and readout definition!" << RESTendl;
+                    RESTError << "channel: " << iter->first << " not fount in mapping file!" << RESTendl;
                     abort();
                 }
             }
 
         } else {
-            RESTFerr << "You must set a TRestDetectorGainMap metadata object to apply gain correction!" << RESTendl;
+            RESTError << "You must set a TRestDetectorGainMap metadata object to apply gain correction!" << RESTendl;
             abort();
         }
     }
 
     if (GetFriend("TRestRawSignalAnalysisProcess") == nullptr) {
-        RESTFerr << "please add friend process TRestRawSignalAnalysisProcess and "
+        RESTError << "please add friend process TRestRawSignalAnalysisProcess and "
                 "TRestRawReadoutAnalysisProcess "
                 "and turn on all their observables!"
              << RESTendl;
@@ -313,7 +313,7 @@ void TRestDetectorSingleChannelAnalysisProcess::InitFromConfigFile() {
         fApplyGainCorrection = true;
         fSingleThreadOnly = false;
     } else {
-        RESTFerr << "illegal mode definition! supported: create, apply" << RESTendl;
+        RESTError << "illegal mode definition! supported: create, apply" << RESTendl;
         abort();
     }
 

--- a/src/TRestDetectorSingleChannelAnalysisProcess.cxx
+++ b/src/TRestDetectorSingleChannelAnalysisProcess.cxx
@@ -66,23 +66,23 @@ void TRestDetectorSingleChannelAnalysisProcess::InitProcess() {
         if (fCalib != nullptr) {
             for (auto iter = fChannelGain.begin(); iter != fChannelGain.end(); iter++) {
                 if (fCalib->fChannelGain.count(iter->first) == 0) {
-                    ferr << "in consistent gain mapping and readout definition!" << endl;
-                    ferr << "channel: " << iter->first << " not fount in mapping file!" << endl;
+                    RESTFerr << "in consistent gain mapping and readout definition!" << RESTendl;
+                    RESTFerr << "channel: " << iter->first << " not fount in mapping file!" << RESTendl;
                     abort();
                 }
             }
 
         } else {
-            ferr << "You must set a TRestDetectorGainMap metadata object to apply gain correction!" << endl;
+            RESTFerr << "You must set a TRestDetectorGainMap metadata object to apply gain correction!" << RESTendl;
             abort();
         }
     }
 
     if (GetFriend("TRestRawSignalAnalysisProcess") == nullptr) {
-        ferr << "please add friend process TRestRawSignalAnalysisProcess and "
+        RESTFerr << "please add friend process TRestRawSignalAnalysisProcess and "
                 "TRestRawReadoutAnalysisProcess "
                 "and turn on all their observables!"
-             << endl;
+             << RESTendl;
         abort();
     }
 }
@@ -313,7 +313,7 @@ void TRestDetectorSingleChannelAnalysisProcess::InitFromConfigFile() {
         fApplyGainCorrection = true;
         fSingleThreadOnly = false;
     } else {
-        ferr << "illegal mode definition! supported: create, apply" << endl;
+        RESTFerr << "illegal mode definition! supported: create, apply" << RESTendl;
         abort();
     }
 


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Large: 421](https://badgen.net/badge/PR%20Size/Large%3A%20421/red) [![](https://gitlab.cern.ch/rest-for-physics/detectorlib/badges/RESTendl/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/detectorlib/-/commits/RESTendl) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/RESTendl/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/RESTendl)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Related with https://github.com/rest-for-physics/framework/pull/225:
- Renamed custom `endl` to `RESTendl`
- Renamed other logger functions
  - `info` --> `RESTInfo`  
  - `debug` --> `RESTDebug`
  - `essential` --> `RESTEssential`
  - `warning` --> `RESTWarning`
  - `fout` --> `RESTcout`
  - `ferr` --> `RESTError`