### PR TITLE
replaced dynamic length array initializaion

### DIFF
--- a/src/TRestDetectorHitsEvent.cxx
+++ b/src/TRestDetectorHitsEvent.cxx
@@ -681,9 +681,9 @@ void TRestDetectorHitsEvent::DrawGraphs(Int_t& column) {
         fYZHitGraph = nullptr;
     }
 
-    Double_t xz[2][this->GetNumberOfHits()];
-    Double_t yz[2][this->GetNumberOfHits()];
-    Double_t xy[2][this->GetNumberOfHits()];
+    vector<vector<Double_t>> xz(2, vector<Double_t>(this->GetNumberOfHits()));
+    vector<vector<Double_t>> yz(2, vector<Double_t>(this->GetNumberOfHits()));
+    vector<vector<Double_t>> xy(2, vector<Double_t>(this->GetNumberOfHits()));
 
     /* {{{ Creating xz, yz, and xy arrays and initializing graphs */
     Int_t nXZ = 0;
@@ -715,17 +715,17 @@ void TRestDetectorHitsEvent::DrawGraphs(Int_t& column) {
         }
     }
 
-    fXZHitGraph = new TGraph(nXZ, xz[0], xz[1]);
+    fXZHitGraph = new TGraph(nXZ, &xz[0][0], &xz[1][0]);
     fXZHitGraph->SetMarkerColor(kBlue);
     fXZHitGraph->SetMarkerSize(0.3);
     fXZHitGraph->SetMarkerStyle(20);
 
-    fYZHitGraph = new TGraph(nYZ, yz[0], yz[1]);
+    fYZHitGraph = new TGraph(nYZ, &yz[0][0], &yz[1][0]);
     fYZHitGraph->SetMarkerColor(kRed);
     fYZHitGraph->SetMarkerSize(0.3);
     fYZHitGraph->SetMarkerStyle(20);
 
-    fXYHitGraph = new TGraph(nXY, xy[0], xy[1]);
+    fXYHitGraph = new TGraph(nXY, &xy[0][0], &xy[1][0]);
     fXYHitGraph->SetMarkerColor(kBlack);
     fXYHitGraph->SetMarkerSize(0.3);
     fXYHitGraph->SetMarkerStyle(20);

--- a/src/TRestDetectorReadoutModule.cxx
+++ b/src/TRestDetectorReadoutModule.cxx
@@ -44,8 +44,6 @@
 
 #include "TRestDetectorReadoutModule.h"
 
-#include "unistd.h"
-
 using namespace std;
 
 ClassImp(TRestDetectorReadoutModule);


### PR DESCRIPTION
![nkx111](https://badgen.net/badge/PR%20submitted%20by%3A/nkx111/blue) ![Ok: 6](https://badgen.net/badge/PR%20Size/Ok%3A%206/green) [![](https://gitlab.cern.ch/rest-for-physics/detectorlib/badges/windows-compile/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/detectorlib/-/commits/windows-compile) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/windows-compile/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/windows-compile)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Related to https://github.com/rest-for-physics/framework/pull/231. Array initialization with dynamic length is not available for msvc. Changed to vector. e.g. `Double_t x[nHits];` --> `vector<Double_t> x(nHits);`