### PR TITLE
Adding github detectorlib pipeline

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,0 +1,49 @@
+name: Validation
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  release:
+
+  workflow_dispatch:
+
+env:
+  CMAKE_BUILD_TYPE: Release
+  REST_PATH: /rest/detectorlib/install
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  framework-validation:
+    uses: rest-for-physics/framework/.github/workflows/validation.yml@master
+  
+  libCheck:
+    name: Validate library
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics-dev
+    steps:
+      - uses: actions/checkout@v3
+      - run:  python3 pipeline/validateLibrary.py .
+
+  build-detectorlib:
+    name: Build only detectorlib
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics-dev
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build and install
+        uses: rest-for-physics/framework/.github/actions/build@master
+        with:
+          cmake-flags: "-DCMAKE_INSTALL_PREFIX=${{ env.REST_PATH }} -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DREST_WELCOME=ON -DRESTLIB_DETECTOR=ON"
+          branch: ${{ env.BRANCH_NAME }}
+      - name: Load REST libraries
+        run: |
+          source ${{ env.REST_PATH }}/thisREST.sh
+          restRoot -b -q


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 49](https://badgen.net/badge/PR%20Size/Ok%3A%2049/green) [![](https://gitlab.cern.ch/rest-for-physics/detectorlib/badges/master/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/detectorlib/-/commits/master) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/master/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/master)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Added github pipeline to detectorlib:

 - Replicates gitlab pipeline, although only stand alone build of detectorlib is performed
 - Check against framework pipeline
 - Contributes to https://github.com/rest-for-physics/framework/issues/45