### PR TITLE
Gaus fit signal to hits

### DIFF
--- a/inc/TRestDetectorSignal.h
+++ b/inc/TRestDetectorSignal.h
@@ -54,6 +54,7 @@ class TRestDetectorSignal {
     Int_t GetMaxIndex(Int_t from = 0, Int_t to = 0);
 
     TVector2 GetMaxGauss();
+    TVector2 GetMaxLandau();
 
     // Getters
     TVector2 GetPoint(Int_t n) {

--- a/inc/TRestDetectorSignal.h
+++ b/inc/TRestDetectorSignal.h
@@ -55,6 +55,7 @@ class TRestDetectorSignal {
 
     TVector2 GetMaxGauss();
     TVector2 GetMaxLandau();
+    TVector2 GetMaxAget();
 
     // Getters
     TVector2 GetPoint(Int_t n) {

--- a/inc/TRestDetectorSignal.h
+++ b/inc/TRestDetectorSignal.h
@@ -60,6 +60,8 @@ class TRestDetectorSignal : public TObject {
     // TODO other objects should probably skip using GetMaxIndex direclty
     Int_t GetMaxIndex(Int_t from = 0, Int_t to = 0);
 
+    TVector2 GetMaxGauss();
+
     // Getters
     TVector2 GetPoint(Int_t n) {
         TVector2 vector2(GetTime(n), GetData(n));

--- a/inc/TRestDetectorSignalToHitsProcess.h
+++ b/inc/TRestDetectorSignalToHitsProcess.h
@@ -68,9 +68,6 @@ class TRestDetectorSignalToHitsProcess : public TRestEventProcess {
     // Threshold value for in case intwindow method is requested
     Double_t fThreshold = 100.;
 
-    // Sampling time in us for gaussFit and landauFit methods.
-    Double_t fSampling;  // us
-
    public:
     any GetInputEvent() const override { return fSignalEvent; }
     any GetOutputEvent() const override { return fHitsEvent; }

--- a/inc/TRestDetectorSignalToHitsProcess.h
+++ b/inc/TRestDetectorSignalToHitsProcess.h
@@ -68,7 +68,7 @@ class TRestDetectorSignalToHitsProcess : public TRestEventProcess {
     // Threshold value for in case intwindow method is requested
     Double_t fThreshold = 100.;
 
-    // Sampling time in us for gaussFit method.
+    // Sampling time in us for gaussFit and landauFit methods.
     Double_t fSampling;  // us
 
    public:

--- a/inc/TRestDetectorSignalToHitsProcess.h
+++ b/inc/TRestDetectorSignalToHitsProcess.h
@@ -68,6 +68,9 @@ class TRestDetectorSignalToHitsProcess : public TRestEventProcess {
     // Threshold value for in case intwindow method is requested
     Double_t fThreshold = 100.;
 
+    // Sampling time in us for gaussFit method.
+    Double_t fSampling;  // us
+
    public:
     any GetInputEvent() const override { return fSignalEvent; }
     any GetOutputEvent() const override { return fHitsEvent; }

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -294,12 +294,13 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
         energy = -1;
         index = -1;
         time = -1;
-        cout << " ------------------- WARNING: bad fit to signal with ID " << GetID() << "-------------------"
-             << endl;
-        cout << "maxRawTime = " << maxRawTime << " ns " << endl;
-        cout << "Failed fit parameters = " << gaus->GetParameter(0) << " || " << gaus->GetParameter(1)
-             << " || " << gaus->GetParameter(2) << endl;
-        cout << "Assigned fit parameters : energy = " << energy << ", time = " << time << endl;
+        cout << endl
+             << "WARNING: bad fit to signal with ID " << GetID() << " with maximum at time = " << maxRawTime
+             << " ns "
+             << "\n"
+             << "Failed fit parameters = " << gaus->GetParameter(0) << " || " << gaus->GetParameter(1)
+             << " || " << gaus->GetParameter(2) << "\n"
+             << "Assigned fit parameters : energy = " << energy << ", time = " << time << endl;
         /*
         TCanvas* c2 = new TCanvas("c2", "Signal fit", 200, 10, 1280, 720);
         h1->Draw();
@@ -343,7 +344,6 @@ TRestDetectorSignal::GetMaxLandau()  // returns a 2vector with the time of the p
     TFitResultPtr fitResult =
         h1->Fit(landau, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in the function range;
                                   // S = save and return the fit result
-
     if (fitResult->IsValid()) {
         energy = landau->GetParameter(0);
         time = landau->GetParameter(1);
@@ -352,13 +352,13 @@ TRestDetectorSignal::GetMaxLandau()  // returns a 2vector with the time of the p
         energy = -1;
         index = -1;
         time = -1;
-        cout << " ------------------- WARNING: bad fit to signal with ID " << GetID() << "-------------------"
-             << endl;
-        cout << "------------------- with maximum at time = " << maxRawTime << " ns ------------------"
-             << endl;
-        cout << "Failed fit parameters = " << landau->GetParameter(0) << " || " << landau->GetParameter(1)
-             << " || " << landau->GetParameter(2) << endl;
-        cout << "Assigned fit parameters : energy = " << energy << ", time = " << time << endl;
+        cout << endl
+             << "WARNING: bad fit to signal with ID " << GetID() << " with maximum at time = " << maxRawTime
+             << " ns "
+             << "\n"
+             << "Failed fit parameters = " << landau->GetParameter(0) << " || " << landau->GetParameter(1)
+             << " || " << landau->GetParameter(2) << "\n"
+             << "Assigned fit parameters : energy = " << energy << ", time = " << time << endl;
         /*
         TCanvas* c2 = new TCanvas("c2", "Signal fit", 200, 10, 1280, 720);
         h1->Draw();
@@ -425,13 +425,13 @@ TRestDetectorSignal::GetMaxAget()  // returns a 2vector with the time of the pea
         energy = -1;
         index = -1;
         time = -1;
-        cout << " ------------------- WARNING: bad fit to signal with ID " << GetID() << "-------------------"
-             << endl;
-        cout << "------------------------ with maximum at time = " << maxRawTime
-             << " ns -----------------------" << endl;
-        cout << "Failed fit parameters = " << aget->GetParameter(0) << " || " << aget->GetParameter(1)
-             << " || " << aget->GetParameter(2) << endl;
-        cout << "Assigned fit parameters : energy = " << energy << ", time = " << time << endl;
+        cout << endl
+             << "WARNING: bad fit to signal with ID " << GetID() << " with maximum at time = " << maxRawTime
+             << " ns "
+             << "\n"
+             << "Failed fit parameters = " << aget->GetParameter(0) << " || " << aget->GetParameter(1)
+             << " || " << aget->GetParameter(2) << "\n"
+             << "Assigned fit parameters : energy = " << energy << ", time = " << time << endl;
         /*
         TCanvas* c2 = new TCanvas("c2", "Signal fit", 200, 10, 1280, 720);
         h1->Draw();

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -300,55 +300,19 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
         cout << "Failed fit parameters = " << gaus->GetParameter(0) << " || " << gaus->GetParameter(1)
              << " || " << gaus->GetParameter(2) << endl;
         cout << "Assigned fit parameters : energy = " << energy << ", time = " << time << endl;
+        /*
+        TCanvas* c2 = new TCanvas("c2", "Signal fit", 200, 10, 1280, 720);
+        h1->Draw();
+        c2->Update();
+        getchar();
+        delete c2;
+        */
     }
-
-    // c->Update();
-
-    /*
-    cout << " fit parameters = " << gaus->GetParameter(0) << " || " << gaus->GetParameter(1) << " || "
-         << gaus->GetParameter(2) << " || " << endl;
-    cout << "GetMaxIndex = " << maxRaw << " GetMaxPeakValue = " << maxRawValue << endl;
-    getchar();
-    */
-
-    /*
-    if (!TMath::IsNaN(gaus->GetParameter(0)) && !TMath::IsNaN(gaus->GetParameter(1)) &&
-        gaus->GetParameter(1) > 0.0) {
-        energy = gaus->GetParameter(0);
-        index = (int)gaus->GetParameter(1);
-        time = gaus->GetParameter(1);
-    }
-    */
-    /*
-    else {
-        // TCanvas* c2 = new TCanvas("c2", "Signal fit", 200, 10, 1280, 720);
-        // h1->Draw();
-        // c2->Update();
-
-        energy = -1;
-        index = -1;
-        time = -1;
-        cout << " ------------------- WARNING: bad fit " << GetID() << "-------------------" << endl;
-        cout << " -------------------- event ID: " << this->GetID() << "-------------------" << endl;
-        cout << "maxRawTime = " << maxRawTime << endl;
-        cout << " fit parameters = " << gaus->GetParameter(0) << " || " << gaus->GetParameter(1) << " || "
-             << gaus->GetParameter(2) << " || " << endl;
-
-        // getchar();
-        // delete c2;
-    }
-    */
 
     TVector2 fitParam(time, energy);
 
-    // cout << "maxRaw : " << maxRaw << " and maxRawValue : " << maxRawValue << endl;
-    // cout << "Time : " << fitParam.X() << " and Energy : " << fitParam.Y() << endl;
-
-    // getchar();
-
     delete h1;
     delete gaus;
-    // delete c;
 
     return fitParam;
 }
@@ -376,34 +340,6 @@ TRestDetectorSignal::GetMaxLandau()  // returns a 2vector with the time of the p
         h1->Fill(GetTime(i), GetData(i));
     }
 
-    /*
-    h1->Fit(landau, "QNR");  // Q = quiet, no info in screen; N = no plot; R = fit in the function range
-
-    if (!TMath::IsNaN(landau->GetParameter(0)) && !TMath::IsNaN(landau->GetParameter(1)) &&
-        landau->GetParameter(1) > 0.0) {
-        energy = landau->GetParameter(0);
-        index = (int)landau->GetParameter(1);
-        time = landau->GetParameter(1);
-    }
-
-    else {
-        // TCanvas* c2 = new TCanvas("c2", "Signal fit", 200, 10, 1280, 720);
-        // h1->Draw();
-        // c2->Update();
-
-        energy = -1;
-        index = -1;
-        time = -1;
-        cout << " ------------------- WARNING: bad fit " << GetID() << "-------------------" << endl;
-        cout << " -------------------- event ID: " << this->GetID() << "-------------------" << endl;
-        cout << "maxRawTime = " << maxRawTime << endl;
-        cout << " fit parameters = " << landau->GetParameter(0) << " || " << landau->GetParameter(1) << " || "
-             << landau->GetParameter(2) << " || " << endl;
-
-        // getchar();
-        // delete c2;
-    }
-    */
     TFitResultPtr fitResult =
         h1->Fit(landau, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in the function range;
                                   // S = save and return the fit result
@@ -423,12 +359,13 @@ TRestDetectorSignal::GetMaxLandau()  // returns a 2vector with the time of the p
         cout << "Failed fit parameters = " << landau->GetParameter(0) << " || " << landau->GetParameter(1)
              << " || " << landau->GetParameter(2) << endl;
         cout << "Assigned fit parameters : energy = " << energy << ", time = " << time << endl;
-
+        /*
         TCanvas* c2 = new TCanvas("c2", "Signal fit", 200, 10, 1280, 720);
         h1->Draw();
         c2->Update();
         getchar();
         delete c2;
+        */
     }
 
     TVector2 fitParam(time, energy);
@@ -475,49 +412,7 @@ TRestDetectorSignal::GetMaxAget()  // returns a 2vector with the time of the pea
     for (int i = 0; i < GetNumberOfPoints(); i++) {
         h1->Fill(GetTime(i), GetData(i));
     }
-    /*
-    TCanvas* c = new TCanvas("c", "Signal fit", 200, 10, 1280, 720);
-    h1->GetXaxis()->SetTitle("Time (us)");
-    h1->GetYaxis()->SetTitle("Amplitude");
-    h1->Draw();
-    */
 
-    // h1->Fit(aget, "QNR");  // Q = quiet, no info in screen; N = no plot; R = fit in the function range
-
-    // c->Update();
-
-    /*
-    cout << " fit parameters = " << aget->GetParameter(0) << " || " << aget->GetParameter(1) << " || "
-         << aget->GetParameter(2) << " || " << endl;
-    cout << "GetMaxIndex = " << maxRaw << " GetMaxPeakValue = " << maxRawValue << endl;
-    getchar();
-    */
-    /*
-    if (!TMath::IsNaN(aget->GetParameter(0)) && !TMath::IsNaN(aget->GetParameter(1)) &&
-        aget->GetParameter(1) > 0.0) {
-        energy = aget->GetParameter(0);
-        index = (int)aget->GetParameter(1);
-        time = aget->GetParameter(1);
-    }
-
-    else {
-        // TCanvas* c2 = new TCanvas("c2", "Signal fit", 200, 10, 1280, 720);
-        // h1->Draw();
-        // c2->Update();
-
-        energy = -1;
-        index = -1;
-        time = -1;
-        cout << " ------------------- WARNING: bad fit " << GetID() << "-------------------" << endl;
-        cout << " -------------------- event ID: " << this->GetID() << "-------------------" << endl;
-        cout << "maxRawTime = " << maxRawTime << endl;
-        cout << " fit parameters = " << aget->GetParameter(0) << " || " << aget->GetParameter(1) << " || "
-             << aget->GetParameter(2) << " || " << endl;
-
-        // getchar();
-        // delete c2;
-    }
-    */
     TFitResultPtr fitResult = h1->Fit(aget, "QRS");  // Q = quiet, no info in screen; N = no plot; R = fit in
                                                      // the function range; S = save and return the fit result
 
@@ -536,23 +431,19 @@ TRestDetectorSignal::GetMaxAget()  // returns a 2vector with the time of the pea
         cout << "Failed fit parameters = " << aget->GetParameter(0) << " || " << aget->GetParameter(1)
              << " || " << aget->GetParameter(2) << endl;
         cout << "Assigned fit parameters : energy = " << energy << ", time = " << time << endl;
+        /*
         TCanvas* c2 = new TCanvas("c2", "Signal fit", 200, 10, 1280, 720);
         h1->Draw();
         c2->Update();
         getchar();
         delete c2;
+        */
     }
 
     TVector2 fitParam(time, energy);
 
-    // cout << "maxRaw : " << maxRaw << " and maxRawValue : " << maxRawValue << endl;
-    // cout << "Time : " << fitParam.X() << " and Energy : " << fitParam.Y() << endl;
-
-    // getchar();
-
     delete h1;
     delete aget;
-    // delete c;
 
     return fitParam;
 }

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -31,7 +31,7 @@ using namespace std;
 #include <TH1.h>
 #include <TMath.h>
 #include <TRandom3.h>
-#include "TCanvas.h"  // (Elisa)
+#include "TCanvas.h"
 
 ClassImp(TRestDetectorSignal);
 
@@ -258,8 +258,9 @@ Int_t TRestDetectorSignal::GetMaxIndex(Int_t from, Int_t to) {
 TVector2
 TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the peak time in us and the energy
 {
-    Int_t maxRaw = GetMaxIndex();        // The bin where the maximum of the raw signal is found
-    Int_t maxRawTime = GetTime(maxRaw);  // The time of the bin where the maximum of the raw signal is found
+    Int_t maxRaw = GetMaxIndex();  // The bin where the maximum of the raw signal is found
+    Double_t maxRawTime =
+        GetTime(maxRaw);  // The time of the bin where the maximum of the raw signal is found
     Double_t maxRawValue = GetMaxPeakValue();  // The height (amplitude) of the maximum of the raw signal
     Int_t index = 0;
     Double_t energy = 0, time = 0;
@@ -298,21 +299,21 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
     }
 
     else {
-        TCanvas* c2 = new TCanvas("c2", "Signal fit", 200, 10, 1280, 720);
-        h1->Draw();
-        c2->Update();
+        // TCanvas* c2 = new TCanvas("c2", "Signal fit", 200, 10, 1280, 720);
+        // h1->Draw();
+        // c2->Update();
 
         energy = -1;
         index = -1;
         time = -1;
         cout << " ------------------- WARNING: bad fit " << GetID() << "-------------------" << endl;
         cout << " -------------------- event ID: " << this->GetID() << "-------------------" << endl;
-        cout << "maxRaw = " << maxRaw << endl;
+        cout << "maxRawTime = " << maxRawTime << endl;
         cout << " fit parameters = " << gaus->GetParameter(0) << " || " << gaus->GetParameter(1) << " || "
              << gaus->GetParameter(2) << " || " << endl;
 
         // getchar();
-        delete c2;
+        // delete c2;
     }
 
     TVector2 fitParam(time, energy);
@@ -334,8 +335,9 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
 TVector2
 TRestDetectorSignal::GetMaxLandau()  // returns a 2vector with the time of the peak time in us and the energy
 {
-    Int_t maxRaw = GetMaxIndex();        // The bin where the maximum of the raw signal is found
-    Int_t maxRawTime = GetTime(maxRaw);  // The time of the bin where the maximum of the raw signal is found
+    Int_t maxRaw = GetMaxIndex();  // The bin where the maximum of the raw signal is found
+    Double_t maxRawTime =
+        GetTime(maxRaw);  // The time of the bin where the maximum of the raw signal is found
     Double_t maxRawValue = GetMaxPeakValue();  // The height (amplitude) of the maximum of the raw signal
     Int_t index = 0;
     Double_t energy = 0, time = 0;
@@ -360,6 +362,10 @@ TRestDetectorSignal::GetMaxLandau()  // returns a 2vector with the time of the p
     }
 
     else {
+        // TCanvas* c2 = new TCanvas("c2", "Signal fit", 200, 10, 1280, 720);
+        // h1->Draw();
+        // c2->Update();
+
         energy = -1;
         index = -1;
         time = -1;
@@ -368,6 +374,9 @@ TRestDetectorSignal::GetMaxLandau()  // returns a 2vector with the time of the p
         cout << "maxRawTime = " << maxRawTime << endl;
         cout << " fit parameters = " << landau->GetParameter(0) << " || " << landau->GetParameter(1) << " || "
              << landau->GetParameter(2) << " || " << endl;
+
+        // getchar();
+        // delete c2;
     }
 
     TVector2 fitParam(time, energy);
@@ -395,8 +404,9 @@ Double_t agetResponseFunction(Double_t* x, Double_t* par) {  // x contains as ma
 TVector2
 TRestDetectorSignal::GetMaxAget()  // returns a 2vector with the time of the peak time in us and the energy
 {
-    Int_t maxRaw = GetMaxIndex();        // The bin where the maximum of the raw signal is found
-    Int_t maxRawTime = GetTime(maxRaw);  // The time of the bin where the maximum of the raw signal is found
+    Int_t maxRaw = GetMaxIndex();  // The bin where the maximum of the raw signal is found
+    Double_t maxRawTime =
+        GetTime(maxRaw);  // The time of the bin where the maximum of the raw signal is found
     Double_t maxRawValue = GetMaxPeakValue();  // The height (amplitude) of the maximum of the raw signal
     Int_t index = 0;
     Double_t energy = 0, time = 0;
@@ -439,21 +449,21 @@ TRestDetectorSignal::GetMaxAget()  // returns a 2vector with the time of the pea
     }
 
     else {
-        TCanvas* c2 = new TCanvas("c2", "Signal fit", 200, 10, 1280, 720);
-        h1->Draw();
-        c2->Update();
+        // TCanvas* c2 = new TCanvas("c2", "Signal fit", 200, 10, 1280, 720);
+        // h1->Draw();
+        // c2->Update();
 
         energy = -1;
         index = -1;
         time = -1;
         cout << " ------------------- WARNING: bad fit " << GetID() << "-------------------" << endl;
         cout << " -------------------- event ID: " << this->GetID() << "-------------------" << endl;
-        cout << "maxRaw = " << maxRaw << endl;
+        cout << "maxRawTime = " << maxRawTime << endl;
         cout << " fit parameters = " << aget->GetParameter(0) << " || " << aget->GetParameter(1) << " || "
              << aget->GetParameter(2) << " || " << endl;
 
         // getchar();
-        delete c2;
+        // delete c2;
     }
 
     TVector2 fitParam(time, energy);

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -253,7 +253,7 @@ Int_t TRestDetectorSignal::GetMaxIndex(Int_t from, Int_t to) {
     return index;
 }
 
-// (Elisa) z position by gaussian fit
+// z position by gaussian fit
 
 TVector2
 TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the peak (bin units) and the energy
@@ -264,28 +264,31 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
     Double_t energy = 0, time = 0;
     Double_t w = 0;
 
-    // cout << " ------------------- event ID: " << GetID() << endl;
-    // cout << "maxRaw = " << maxRaw << endl;
+    cout << " ------------------- event ID: " << GetID() << "-------------------" << endl;
+    cout << "Bin of the maximum amplitude signal = " << maxRaw << ", with value: " << maxRawValue << endl;
 
     TF1* gaus = new TF1("gaus", "gaus", maxRaw - 12, maxRaw + 15);  // The max of the signal is ~40 bins wide
     TH1F* h1 = new TH1F("h1", "h1", 512, 0, 511);                   // Histogram to store the signal
 
     // copying the signal peak to a histogram
-    // for( int i = maxRaw - 20; i < maxRaw + 20; i++ )
+    // for( int i = maxRaw - 20; i < maxRaw + 20; i++ ) {
     for (int i = 0; i < GetNumberOfPoints(); i++) {
         w = GetData(i);
         h1->Fill(i, w);
+        // if (w > 200) h1->Fill(i, w);
     }
 
     // TCanvas *c = new TCanvas("c","signal fit",200,10,1280,720);
+    // h1->GetXaxis()->SetTitle("Time bins");
+    // h1->GetYaxis()->SetTitle("Amplitude");
     // h1->Draw();
 
     h1->Fit(gaus, "QNR");  // Q = quiet, no info in screen; N = no plot; R = fit in the function range
 
-    // c->Update();
+    c->Update();
 
     // cout << " fit parameters = "<< gaus->GetParameter(0) << " || " << gaus->GetParameter(1) << " || " <<
-    // gaus->GetParameter(2) << " || "<<endl; cout << "GetMaxIndex" << maxRaw << " GetMaxPeakValue = " <<
+    // gaus->GetParameter(2) << " || "<<endl; cout << "GetMaxIndex = " << maxRaw << " GetMaxPeakValue = " <<
     // maxRawValue << endl; getchar();
 
     if (!TMath::IsNaN(gaus->GetParameter(0)) && !TMath::IsNaN(gaus->GetParameter(1)) &&

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -413,8 +413,9 @@ TRestDetectorSignal::GetMaxAget()  // returns a 2vector with the time of the pea
         h1->Fill(GetTime(i), GetData(i));
     }
 
-    TFitResultPtr fitResult = h1->Fit(aget, "QRS");  // Q = quiet, no info in screen; N = no plot; R = fit in
-                                                     // the function range; S = save and return the fit result
+    TFitResultPtr fitResult =
+        h1->Fit(aget, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in
+                                // the function range; S = save and return the fit result
 
     if (fitResult->IsValid()) {
         energy = aget->GetParameter(0);

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -277,21 +277,22 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
     for (int i = 0; i < GetNumberOfPoints(); i++) {
         h1->Fill(GetTime(i), GetData(i));
     }
-
+    /*
     TCanvas* c = new TCanvas("c", "Signal fit", 200, 10, 1280, 720);
     h1->GetXaxis()->SetTitle("Time (us)");
     h1->GetYaxis()->SetTitle("Amplitude");
     h1->Draw();
+    */
 
-    h1->Fit(gaus, "R");  // Q = quiet, no info in screen; N = no plot; R = fit in the function range
+    h1->Fit(gaus, "QNR");  // Q = quiet, no info in screen; N = no plot; R = fit in the function range
 
-    c->Update();
-
+    // c->Update();
+    /*
     cout << " fit parameters = " << gaus->GetParameter(0) << " || " << gaus->GetParameter(1) << " || "
          << gaus->GetParameter(2) << " || " << endl;
     cout << "GetMaxIndex = " << maxRaw << " GetMaxPeakValue = " << maxRawValue << endl;
     getchar();
-
+    */
     if (!TMath::IsNaN(gaus->GetParameter(0)) && !TMath::IsNaN(gaus->GetParameter(1)) &&
         gaus->GetParameter(1) > 0.0) {
         energy = gaus->GetParameter(0);
@@ -358,14 +359,15 @@ TRestDetectorSignal::GetMaxLandau()  // returns a 2vector with the time of the p
     h1->GetYaxis()->SetTitle("Amplitude");
     h1->Draw();
 
-    h1->Fit(landau, "R");  // Q = quiet, no info in screen; N = no plot; R = fit in the function range
+    h1->Fit(landau, "QNR");  // Q = quiet, no info in screen; N = no plot; R = fit in the function range
 
-    c->Update();
-
+    // c->Update();
+    /*
     cout << " fit parameters = " << landau->GetParameter(0) << " || " << landau->GetParameter(1) << " || "
          << landau->GetParameter(2) << " || " << endl;
     cout << "GetMaxIndex = " << maxRaw << " GetMaxPeakValue = " << maxRawValue << endl;
     getchar();
+    */
 
     if (!TMath::IsNaN(landau->GetParameter(0)) && !TMath::IsNaN(landau->GetParameter(1)) &&
         landau->GetParameter(1) > 0.0) {

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -265,11 +265,7 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
     Double_t energy = 0, time = 0;
     Double_t w = 0;
 
-    // cout << " ------------------- event ID: " << GetID() << "-------------------" << endl;
-    // cout << "Bin of the maximum amplitude signal = " << maxRaw << ", with value: " << maxRawValue << endl;
-
-    TF1* gaus = new TF1("gaus", "gaus", maxRawTime - 0.2,
-                        maxRawTime + 0.4);  // The max of the signal is ~40 bins wide
+    TF1* gaus = new TF1("gaus", "gaus", maxRawTime - 0.2, maxRawTime + 0.4);
     TH1F* h1 = new TH1F("h1", "h1", 1000, 0,
                         10);  // Histogram to store the signal. For now the number of bins is fixed.
 
@@ -308,8 +304,8 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
         energy = -1;
         index = -1;
         time = -1;
-        cout << " --------------------------------------------------- WARNING: bad fit " << GetID() << endl;
-        cout << " ------------------- event ID: " << this->GetID() << endl;
+        cout << " ------------------- WARNING: bad fit " << GetID() << "-------------------" << endl;
+        cout << " -------------------- event ID: " << this->GetID() << "-------------------" << endl;
         cout << "maxRaw = " << maxRaw << endl;
         cout << " fit parameters = " << gaus->GetParameter(0) << " || " << gaus->GetParameter(1) << " || "
              << gaus->GetParameter(2) << " || " << endl;
@@ -344,8 +340,7 @@ TRestDetectorSignal::GetMaxLandau()  // returns a 2vector with the time of the p
     Double_t energy = 0, time = 0;
     Double_t w = 0;
 
-    TF1* landau = new TF1("landau", "landau", maxRawTime - 0.2,
-                          maxRawTime + 0.4);  // The max of the signal is ~40 bins wide
+    TF1* landau = new TF1("landau", "landau", maxRawTime - 0.2, maxRawTime + 0.4);
     TH1F* h1 = new TH1F("h1", "h1", 1000, 0,
                         10);  // Histogram to store the signal. For now the number of bins is fixed.
 
@@ -354,20 +349,7 @@ TRestDetectorSignal::GetMaxLandau()  // returns a 2vector with the time of the p
         h1->Fill(GetTime(i), GetData(i));
     }
 
-    TCanvas* c = new TCanvas("c", "Signal fit", 200, 10, 1280, 720);
-    h1->GetXaxis()->SetTitle("Time (us)");
-    h1->GetYaxis()->SetTitle("Amplitude");
-    h1->Draw();
-
     h1->Fit(landau, "QNR");  // Q = quiet, no info in screen; N = no plot; R = fit in the function range
-
-    // c->Update();
-    /*
-    cout << " fit parameters = " << landau->GetParameter(0) << " || " << landau->GetParameter(1) << " || "
-         << landau->GetParameter(2) << " || " << endl;
-    cout << "GetMaxIndex = " << maxRaw << " GetMaxPeakValue = " << maxRawValue << endl;
-    getchar();
-    */
 
     if (!TMath::IsNaN(landau->GetParameter(0)) && !TMath::IsNaN(landau->GetParameter(1)) &&
         landau->GetParameter(1) > 0.0) {
@@ -377,20 +359,14 @@ TRestDetectorSignal::GetMaxLandau()  // returns a 2vector with the time of the p
     }
 
     else {
-        TCanvas* c2 = new TCanvas("c2", "Signal fit", 200, 10, 1280, 720);
-        h1->Draw();
-        c2->Update();
-
         energy = -1;
         index = -1;
         time = -1;
-        cout << " --------------------------------------------------- WARNING: bad fit " << GetID() << endl;
-        cout << " ------------------- event ID: " << this->GetID() << endl;
-        cout << "maxRaw = " << maxRaw << endl;
+        cout << " ------------------- WARNING: bad fit " << GetID() << "-------------------" << endl;
+        cout << " -------------------- event ID: " << this->GetID() << "-------------------" << endl;
+        cout << "maxRawTime = " << maxRawTime << endl;
         cout << " fit parameters = " << landau->GetParameter(0) << " || " << landau->GetParameter(1) << " || "
              << landau->GetParameter(2) << " || " << endl;
-
-        delete c2;
     }
 
     TVector2 fitParam(time, energy);

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -285,7 +285,7 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
 
     h1->Fit(gaus, "QNR");  // Q = quiet, no info in screen; N = no plot; R = fit in the function range
 
-    c->Update();
+    // c->Update();
 
     // cout << " fit parameters = "<< gaus->GetParameter(0) << " || " << gaus->GetParameter(1) << " || " <<
     // gaus->GetParameter(2) << " || "<<endl; cout << "GetMaxIndex = " << maxRaw << " GetMaxPeakValue = " <<

--- a/src/TRestDetectorSignalToHitsProcess.cxx
+++ b/src/TRestDetectorSignalToHitsProcess.cxx
@@ -391,7 +391,7 @@ TRestEvent* TRestDetectorSignalToHitsProcess::ProcessEvent(TRestEvent* inputEven
                      << " Energy : " << energy << endl;
             }
 
-            fHitsEvent->AddHit(x, y, z, energy);
+            fHitsEvent->AddHit(x, y, z, energy, 0, type);
 
         } else if (fMethod == "landauFit") {
             TVector2 landauFit = sgnl->GetMaxLandau();
@@ -425,7 +425,7 @@ TRestEvent* TRestDetectorSignalToHitsProcess::ProcessEvent(TRestEvent* inputEven
                      << " Energy : " << energy << endl;
             }
 
-            fHitsEvent->AddHit(x, y, z, energy);
+            fHitsEvent->AddHit(x, y, z, energy, 0, type);
 
         } else if (fMethod == "agetFit") {
             TVector2 agetFit = sgnl->GetMaxAget();
@@ -459,7 +459,7 @@ TRestEvent* TRestDetectorSignalToHitsProcess::ProcessEvent(TRestEvent* inputEven
                      << " Energy : " << energy << endl;
             }
 
-            fHitsEvent->AddHit(x, y, z, energy);
+            fHitsEvent->AddHit(x, y, z, energy, 0, type);
 
         } else if (fMethod == "qCenter") {
             Double_t energy_signal = 0;

--- a/src/TRestDetectorSignalToHitsProcess.cxx
+++ b/src/TRestDetectorSignalToHitsProcess.cxx
@@ -386,6 +386,39 @@ TRestEvent* TRestDetectorSignalToHitsProcess::ProcessEvent(TRestEvent* inputEven
 
             fHitsEvent->AddHit(x, y, z, energy);
 
+        } else if (fMethod == "landauFit") {
+            TVector2 landauFit = sgnl->GetMaxLandau();
+
+            // cout << "Landau Fit: time = " << landauFit.X() << "; and energy = " << landauFit.Y() << endl;
+
+            Double_t time = landauFit.X() * fSampling;  // time in micros
+            Double_t distanceToPlane = time * fDriftVelocity;
+
+            // Double_t distanceToPlane = (time - firstSignalPeakTime)* fSampling * fDriftVelocity;
+
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
+                cout << "Distance to plane : " << distanceToPlane << endl;
+
+            Double_t z = zPosition + fieldZDirection * distanceToPlane;
+
+            // cout << "zPosition : " << zPosition << "; fieldZDirection : " << fieldZDirection << "; sampling
+            // : " << fSampling << " and driftV : " << fDriftVelocity << endl;
+
+            Double_t energy = landauFit.Y();
+
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
+                cout << "Signal event : " << sgnl->GetSignalID()
+                     << "--------------------------------------------------------" << endl;
+                cout << "landauFit : time bin " << landauFit.X() << " and energy : " << landauFit.Y() << endl;
+                cout << "Signal to hit info : zPosition : " << zPosition
+                     << "; fieldZDirection : " << fieldZDirection << "; sampling : " << fSampling
+                     << " and driftV : " << fDriftVelocity << endl;
+                cout << "Adding hit. Time : " << time << " x : " << x << " y : " << y << " z : " << z
+                     << " Energy : " << energy << endl;
+            }
+
+            fHitsEvent->AddHit(x, y, z, energy);
+
         } else if (fMethod == "qCenter") {
             Double_t energy_signal = 0;
             Double_t distanceToPlane = 0;

--- a/src/TRestDetectorSignalToHitsProcess.cxx
+++ b/src/TRestDetectorSignalToHitsProcess.cxx
@@ -358,7 +358,8 @@ TRestEvent* TRestDetectorSignalToHitsProcess::ProcessEvent(TRestEvent* inputEven
 
             // cout << "Gaus Fit: time = " << gausFit.X() << "; and energy = " << gausFit.Y() << endl;
 
-            Double_t time = gaussFit.X() * fSampling;  // time in micros
+            Double_t time = gaussFit.X();
+            // Double_t time = gaussFit.X() * fSampling;  // time in micros
             Double_t distanceToPlane = time * fDriftVelocity;
 
             // Double_t distanceToPlane = (time - firstSignalPeakTime)* fSampling * fDriftVelocity;
@@ -391,7 +392,8 @@ TRestEvent* TRestDetectorSignalToHitsProcess::ProcessEvent(TRestEvent* inputEven
 
             // cout << "Landau Fit: time = " << landauFit.X() << "; and energy = " << landauFit.Y() << endl;
 
-            Double_t time = landauFit.X() * fSampling;  // time in micros
+            Double_t time = landauFit.X();
+            // Double_t time = landauFit.X() * fSampling;  // time in micros
             Double_t distanceToPlane = time * fDriftVelocity;
 
             // Double_t distanceToPlane = (time - firstSignalPeakTime)* fSampling * fDriftVelocity;

--- a/src/TRestDetectorSignalToHitsProcess.cxx
+++ b/src/TRestDetectorSignalToHitsProcess.cxx
@@ -353,8 +353,7 @@ TRestEvent* TRestDetectorSignalToHitsProcess::ProcessEvent(TRestEvent* inputEven
                 cout << "Adding hit. Time : " << time << " x : " << x << " y : " << y << " z : " << zAvg
                      << " Energy : " << eAvg << endl;
             }
-        } else if (fMethod == "gaussFit") {  // (Based on Elisa's)
-
+        } else if (fMethod == "gaussFit") {
             TVector2 gaussFit = sgnl->GetMaxGauss();
 
             // cout << "Gaus Fit: time = " << gausFit.X() << "; and energy = " << gausFit.Y() << endl;

--- a/src/TRestDetectorSignalToHitsProcess.cxx
+++ b/src/TRestDetectorSignalToHitsProcess.cxx
@@ -353,6 +353,39 @@ TRestEvent* TRestDetectorSignalToHitsProcess::ProcessEvent(TRestEvent* inputEven
                 cout << "Adding hit. Time : " << time << " x : " << x << " y : " << y << " z : " << zAvg
                      << " Energy : " << eAvg << endl;
             }
+        } else if (fMethod == "gaussFit") {  // (Based on Elisa's)
+
+            TVector2 gaussFit = sgnl->GetMaxGauss();
+
+            // cout << "Gaus Fit: time = " << gausFit.X() << "; and energy = " << gausFit.Y() << endl;
+
+            Double_t time = gaussFit.X() * fSampling;  // time in micros
+            Double_t distanceToPlane = time * fDriftVelocity;
+
+            // Double_t distanceToPlane = (time - firstSignalPeakTime)* fSampling * fDriftVelocity;
+
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
+                cout << "Distance to plane : " << distanceToPlane << endl;
+
+            Double_t z = zPosition + fieldZDirection * distanceToPlane;
+
+            // cout << "zPosition : " << zPosition << "; fieldZDirection : " << fieldZDirection << "; sampling
+            // : " << fSampling << " and driftV : " << fDriftVelocity << endl;
+
+            Double_t energy = gaussFit.Y();
+
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
+                cout << "Signal event : " << sgnl->GetSignalID()
+                     << "--------------------------------------------------------" << endl;
+                cout << "GausFit : time bin " << gaussFit.X() << " and energy : " << gaussFit.Y() << endl;
+                cout << "Signal to hit info : zPosition : " << zPosition
+                     << "; fieldZDirection : " << fieldZDirection << "; sampling : " << fSampling
+                     << " and driftV : " << fDriftVelocity << endl;
+                cout << "Adding hit. Time : " << time << " x : " << x << " y : " << y << " z : " << z
+                     << " Energy : " << energy << endl;
+            }
+
+            fHitsEvent->AddHit(x, y, z, energy);
 
         } else if (fMethod == "qCenter") {
             Double_t energy_signal = 0;

--- a/src/TRestDetectorSignalToHitsProcess.cxx
+++ b/src/TRestDetectorSignalToHitsProcess.cxx
@@ -379,8 +379,8 @@ TRestEvent* TRestDetectorSignalToHitsProcess::ProcessEvent(TRestEvent* inputEven
                      << "--------------------------------------------------------" << endl;
                 cout << "GausFit : time bin " << gaussFit.X() << " and energy : " << gaussFit.Y() << endl;
                 cout << "Signal to hit info : zPosition : " << zPosition
-                     << "; fieldZDirection : " << fieldZDirection << "; sampling : " << fSampling
-                     << " and driftV : " << fDriftVelocity << endl;
+                     << "; fieldZDirection : " << fieldZDirection << " and driftV : " << fDriftVelocity
+                     << endl;
                 cout << "Adding hit. Time : " << time << " x : " << x << " y : " << y << " z : " << z
                      << " Energy : " << energy << endl;
             }
@@ -413,8 +413,8 @@ TRestEvent* TRestDetectorSignalToHitsProcess::ProcessEvent(TRestEvent* inputEven
                      << "--------------------------------------------------------" << endl;
                 cout << "landauFit : time bin " << landauFit.X() << " and energy : " << landauFit.Y() << endl;
                 cout << "Signal to hit info : zPosition : " << zPosition
-                     << "; fieldZDirection : " << fieldZDirection << "; sampling : " << fSampling
-                     << " and driftV : " << fDriftVelocity << endl;
+                     << "; fieldZDirection : " << fieldZDirection << " and driftV : " << fDriftVelocity
+                     << endl;
                 cout << "Adding hit. Time : " << time << " x : " << x << " y : " << y << " z : " << z
                      << " Energy : " << energy << endl;
             }

--- a/src/TRestDetectorSignalToHitsProcess.cxx
+++ b/src/TRestDetectorSignalToHitsProcess.cxx
@@ -359,26 +359,20 @@ TRestEvent* TRestDetectorSignalToHitsProcess::ProcessEvent(TRestEvent* inputEven
                 cout << "Adding hit. Time : " << time << " x : " << x << " y : " << y << " z : " << zAvg
                      << " Energy : " << eAvg << endl;
             }
+
         } else if (fMethod == "gaussFit") {
             TVector2 gaussFit = sgnl->GetMaxGauss();
 
-            // cout << "Gaus Fit: time = " << gausFit.X() << "; and energy = " << gausFit.Y() << endl;
-
-            Double_t time = gaussFit.X();
-            // Double_t time = gaussFit.X() * fSampling;  // time in micros
-            Double_t distanceToPlane = time * fDriftVelocity;
-
-            // Double_t distanceToPlane = (time - firstSignalPeakTime)* fSampling * fDriftVelocity;
-
-            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
-                cout << "Distance to plane : " << distanceToPlane << endl;
-
-            Double_t z = zPosition + fieldZDirection * distanceToPlane;
-
-            // cout << "zPosition : " << zPosition << "; fieldZDirection : " << fieldZDirection << "; sampling
-            // : " << fSampling << " and driftV : " << fDriftVelocity << endl;
-
-            Double_t energy = gaussFit.Y();
+            Double_t z = -1.0;
+            if (gaussFit.X() >= 0.0) {
+                Double_t time = gaussFit.X();
+                Double_t distanceToPlane = time * fDriftVelocity;
+                z = zPosition + fieldZDirection * distanceToPlane;
+            }
+            Double_t energy = -1.0;
+            if (gaussFit.Y() >= 0.0) {
+                energy = gaussFit.Y();
+            }
 
             if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
                 cout << "Signal event : " << sgnl->GetSignalID()
@@ -396,23 +390,16 @@ TRestEvent* TRestDetectorSignalToHitsProcess::ProcessEvent(TRestEvent* inputEven
         } else if (fMethod == "landauFit") {
             TVector2 landauFit = sgnl->GetMaxLandau();
 
-            // cout << "Landau Fit: time = " << landauFit.X() << "; and energy = " << landauFit.Y() << endl;
-
-            Double_t time = landauFit.X();
-            // Double_t time = landauFit.X() * fSampling;  // time in micros
-            Double_t distanceToPlane = time * fDriftVelocity;
-
-            // Double_t distanceToPlane = (time - firstSignalPeakTime)* fSampling * fDriftVelocity;
-
-            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
-                cout << "Distance to plane : " << distanceToPlane << endl;
-
-            Double_t z = zPosition + fieldZDirection * distanceToPlane;
-
-            // cout << "zPosition : " << zPosition << "; fieldZDirection : " << fieldZDirection << "; sampling
-            // : " << fSampling << " and driftV : " << fDriftVelocity << endl;
-
-            Double_t energy = landauFit.Y();
+            Double_t z = -1.0;
+            if (landauFit.X() >= 0.0) {
+                Double_t time = landauFit.X();
+                Double_t distanceToPlane = time * fDriftVelocity;
+                z = zPosition + fieldZDirection * distanceToPlane;
+            }
+            Double_t energy = -1.0;
+            if (landauFit.Y() >= 0.0) {
+                energy = landauFit.Y();
+            }
 
             if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
                 cout << "Signal event : " << sgnl->GetSignalID()
@@ -430,23 +417,16 @@ TRestEvent* TRestDetectorSignalToHitsProcess::ProcessEvent(TRestEvent* inputEven
         } else if (fMethod == "agetFit") {
             TVector2 agetFit = sgnl->GetMaxAget();
 
-            // cout << "Aget Fit: time = " << agetFit.X() << "; and energy = " << agetFit.Y() << endl;
-
-            Double_t time = agetFit.X();
-            // Double_t time = agetFit.X() * fSampling;  // time in micros
-            Double_t distanceToPlane = time * fDriftVelocity;
-
-            // Double_t distanceToPlane = (time - firstSignalPeakTime)* fSampling * fDriftVelocity;
-
-            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
-                cout << "Distance to plane : " << distanceToPlane << endl;
-
-            Double_t z = zPosition + fieldZDirection * distanceToPlane;
-
-            // cout << "zPosition : " << zPosition << "; fieldZDirection : " << fieldZDirection << "; sampling
-            // : " << fSampling << " and driftV : " << fDriftVelocity << endl;
-
-            Double_t energy = agetFit.Y();
+            Double_t z = -1.0;
+            if (agetFit.X() >= 0.0) {
+                Double_t time = agetFit.X();
+                Double_t distanceToPlane = time * fDriftVelocity;
+                z = zPosition + fieldZDirection * distanceToPlane;
+            }
+            Double_t energy = -1.0;
+            if (agetFit.Y() >= 0.0) {
+                energy = agetFit.Y();
+            }
 
             if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
                 cout << "Signal event : " << sgnl->GetSignalID()


### PR DESCRIPTION
![cmargalejo](https://badgen.net/badge/PR%20submitted%20by%3A/cmargalejo/blue) ![Large: 289](https://badgen.net/badge/PR%20Size/Large%3A%20289/red) [![](https://gitlab.cern.ch/rest-for-physics/detectorlib/badges/gausFitSignalToHits/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/detectorlib/-/commits/gausFitSignalToHits) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/gausFitSignalToHits/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/gausFitSignalToHits)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR is to implement a new signalto hits method. It performs a gaussian fit to each signal in a signal event, and uses the parameters of this fit in `TRestDetectorSignalToHitsProcess`.

WORK IN PROGRESS
It currently has a bug because the signals in a signal event do not all start in the same time bin. See figure 1, where the black signal starts much earlier than the others.
![image](https://user-images.githubusercontent.com/77193103/187483182-7dc5238d-e2a0-4049-8763-f1075e11f5b8.png)
Figure 1: sample signal event.

So when a histogram is filled with the points of each signal, each of them has a different starting position because some have this tail to the left (fig. 2), and some don't (fig. 3) which affects the gaussian fit parameters.
![image](https://user-images.githubusercontent.com/77193103/187484340-a4c3bcbd-46ac-4d0a-876d-c4894c61263a.png)
Figure 2: histogram used to fit the signal. In this case, there is a tail to the left.
![image](https://user-images.githubusercontent.com/77193103/187483922-5ff947d3-7b4f-4ac8-beed-65eefbc3584b.png)
Figure 3:  histogram used to fit the signal. In this case, there is no tail to the left.

From Fig. 1 we see that all these signals should have a similar z, but using the gaussian fit this is not the case.

Any tip on how to deal with this? @jgalan @DavidDiezIb @nkx111