### PR TITLE
Avoid invoking hardcoded process names

### DIFF
--- a/src/TRestDetectorSingleChannelAnalysisProcess.cxx
+++ b/src/TRestDetectorSingleChannelAnalysisProcess.cxx
@@ -96,13 +96,13 @@ TRestEvent* TRestDetectorSingleChannelAnalysisProcess::ProcessEvent(TRestEvent* 
     Double_t new_ThresholdIntegral = 0;
 
     map<int, Double_t> sAna_max_amplitude_map =
-        fAnalysisTree->GetObservableValue<map<int, Double_t>>("sAna_max_amplitude_map");
+        GetObservableValue<map<int, Double_t>>("max_amplitude_map");
     map<int, Double_t> sAna_thr_integral_map =
-        fAnalysisTree->GetObservableValue<map<int, Double_t>>("sAna_thr_integral_map");
+        GetObservableValue<map<int, Double_t>>("thr_integral_map");
     Double_t sAna_PeakAmplitudeIntegral =
-        fAnalysisTree->GetObservableValue<Double_t>("sAna_PeakAmplitudeIntegral");
-    Double_t sAna_ThresholdIntegral = fAnalysisTree->GetObservableValue<Double_t>("sAna_ThresholdIntegral");
-    Double_t sAna_NumberOfGoodSignals = fAnalysisTree->GetObservableValue<int>("sAna_NumberOfGoodSignals");
+        GetObservableValue<Double_t>("PeakAmplitudeIntegral");
+    Double_t sAna_ThresholdIntegral = GetObservableValue<Double_t>("ThresholdIntegral");
+    Double_t sAna_NumberOfGoodSignals = GetObservableValue<int>("NumberOfGoodSignals");
 
     if (fCreateGainMap) {
         if ((sAna_ThresholdIntegral > fThrIntegralCutRange.X() &&

--- a/src/TRestDetectorSingleChannelAnalysisProcess.cxx
+++ b/src/TRestDetectorSingleChannelAnalysisProcess.cxx
@@ -95,12 +95,9 @@ TRestEvent* TRestDetectorSingleChannelAnalysisProcess::ProcessEvent(TRestEvent* 
     Double_t new_PeakAmplitudeIntegral = 0;
     Double_t new_ThresholdIntegral = 0;
 
-    map<int, Double_t> sAna_max_amplitude_map =
-        GetObservableValue<map<int, Double_t>>("max_amplitude_map");
-    map<int, Double_t> sAna_thr_integral_map =
-        GetObservableValue<map<int, Double_t>>("thr_integral_map");
-    Double_t sAna_PeakAmplitudeIntegral =
-        GetObservableValue<Double_t>("PeakAmplitudeIntegral");
+    map<int, Double_t> sAna_max_amplitude_map = GetObservableValue<map<int, Double_t>>("max_amplitude_map");
+    map<int, Double_t> sAna_thr_integral_map = GetObservableValue<map<int, Double_t>>("thr_integral_map");
+    Double_t sAna_PeakAmplitudeIntegral = GetObservableValue<Double_t>("PeakAmplitudeIntegral");
     Double_t sAna_ThresholdIntegral = GetObservableValue<Double_t>("ThresholdIntegral");
     Double_t sAna_NumberOfGoodSignals = GetObservableValue<int>("NumberOfGoodSignals");
 


### PR DESCRIPTION
![nkx111](https://badgen.net/badge/PR%20submitted%20by%3A/nkx111/blue) ![Ok: 5](https://badgen.net/badge/PR%20Size/Ok%3A%205/green) [![](https://gitlab.cern.ch/rest-for-physics/detectorlib/badges/nkx111-patch-2/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/detectorlib/-/commits/nkx111-patch-2) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/nkx111-patch-2/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/nkx111-patch-2)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Related to https://github.com/rest-for-physics/detectorlib/issues/47 and https://github.com/rest-for-physics/framework/pull/290

No more hard-coded process names. We directly use pure observable names.