### PR TITLE
TRestDetectorGitsGaussAnalysisProcess: added exceptions for failed fits

### DIFF
--- a/src/TRestDetectorHitsGaussAnalysisProcess.cxx
+++ b/src/TRestDetectorHitsGaussAnalysisProcess.cxx
@@ -164,7 +164,12 @@ TRestEvent* TRestDetectorHitsGaussAnalysisProcess::ProcessEvent(TRestEvent* inpu
     Double_t gausSigmaX = fOutputHitsEvent->GetGaussSigmaX();
     Double_t gausSigmaY = fOutputHitsEvent->GetGaussSigmaY();
     Double_t gausSigmaZ = fOutputHitsEvent->GetGaussSigmaZ();
-    Double_t xy2SigmaGaus = (gausSigmaX * gausSigmaX) + (gausSigmaY * gausSigmaY);
+    Double_t xy2SigmaGaus = (gausSigmaX == -1. || gausSigmaY == -1.)
+                                ? -1.
+                                : (gausSigmaX * gausSigmaX) + (gausSigmaY * gausSigmaY);
+    Double_t xySigmaBalanceGaus = (gausSigmaX == -1. || gausSigmaY == -1.)
+                                      ? -1.
+                                      : (gausSigmaX - gausSigmaY) / (gausSigmaX + gausSigmaY);
 
     if (hits->GetNumberOfHits() > 30 && xy2SigmaGaus < 0.05)
         RESTDebug << string("Event ID: ") << to_string(fInputHitsEvent->GetID()) << string("||") << RESTendl;
@@ -173,7 +178,7 @@ TRestEvent* TRestDetectorHitsGaussAnalysisProcess::ProcessEvent(TRestEvent* inpu
     SetObservableValue("ySigmaGaus", gausSigmaY);
     SetObservableValue("zSigmaGaus", gausSigmaZ);
     SetObservableValue("xy2SigmaGaus", xy2SigmaGaus);
-    SetObservableValue("xySigmaBalanceGaus", (gausSigmaX - gausSigmaY) / (gausSigmaX + gausSigmaY));
+    SetObservableValue("xySigmaBalanceGaus", xySigmaBalanceGaus);
 
     // We transform here fHitsEvent if necessary
 


### PR DESCRIPTION
The Gaussian sigma observables return -1 when the fit failed. This was not considered in the observables `xy2SigmaGaus` and `xySigmaBalanceGaus`. This pull request adds exceptions to set the value of these values to -1 as well when the fit failed.

Comparison before / after:

![hitsAnaGauss_xySigmaBalanceGaus](https://user-images.githubusercontent.com/77107394/227937341-7df65f6c-5a4f-49b3-8101-de3fb0a29f4b.png)

![hitsAnaGauss_xy2SigmaGaus](https://user-images.githubusercontent.com/77107394/227937347-938f238e-f338-4884-83cd-ef126cfd9117.png)
