### PR TITLE
TRestDetectorHitsGaussAnalysisProcess: added option to define the err…

### DIFF
--- a/inc/TRestDetectorHitsEvent.h
+++ b/inc/TRestDetectorHitsEvent.h
@@ -102,9 +102,15 @@ class TRestDetectorHitsEvent : public TRestEvent {
     inline Double_t GetSigmaX() const { return fHits->GetSigmaX(); }
     inline Double_t GetSigmaY() const { return fHits->GetSigmaY(); }
 
-    inline Double_t GetGaussSigmaX(Double_t error) { return GetXZHits()->GetGaussSigmaX(error); }
-    inline Double_t GetGaussSigmaY(Double_t error) { return GetYZHits()->GetGaussSigmaY(error); }
-    inline Double_t GetGaussSigmaZ(Double_t error) const { return fHits->GetGaussSigmaZ(error); }
+    inline Double_t GetGaussSigmaX(Double_t error, Int_t nHitsMin) {
+        return GetXZHits()->GetGaussSigmaX(error, nHitsMin);
+    }
+    inline Double_t GetGaussSigmaY(Double_t error, Int_t nHitsMin) {
+        return GetYZHits()->GetGaussSigmaY(error, nHitsMin);
+    }
+    inline Double_t GetGaussSigmaZ(Double_t error, Int_t nHitsMin) const {
+        return fHits->GetGaussSigmaZ(error, nHitsMin);
+    }
 
     inline Double_t GetSigmaZ2() const { return fHits->GetSigmaZ2(); }
     inline Double_t GetSkewXY() const { return fHits->GetSkewXY(); }

--- a/inc/TRestDetectorHitsEvent.h
+++ b/inc/TRestDetectorHitsEvent.h
@@ -102,9 +102,9 @@ class TRestDetectorHitsEvent : public TRestEvent {
     inline Double_t GetSigmaX() const { return fHits->GetSigmaX(); }
     inline Double_t GetSigmaY() const { return fHits->GetSigmaY(); }
 
-    inline Double_t GetGaussSigmaX() { return GetXZHits()->GetGaussSigmaX(); }
-    inline Double_t GetGaussSigmaY() { return GetYZHits()->GetGaussSigmaY(); }
-    inline Double_t GetGaussSigmaZ() const { return fHits->GetGaussSigmaZ(); }
+    inline Double_t GetGaussSigmaX(Double_t error) { return GetXZHits()->GetGaussSigmaX(error); }
+    inline Double_t GetGaussSigmaY(Double_t error) { return GetYZHits()->GetGaussSigmaY(error); }
+    inline Double_t GetGaussSigmaZ(Double_t error) const { return fHits->GetGaussSigmaZ(error); }
 
     inline Double_t GetSigmaZ2() const { return fHits->GetSigmaZ2(); }
     inline Double_t GetSkewXY() const { return fHits->GetSkewXY(); }

--- a/inc/TRestDetectorHitsGaussAnalysisProcess.h
+++ b/inc/TRestDetectorHitsGaussAnalysisProcess.h
@@ -51,6 +51,8 @@ class TRestDetectorHitsGaussAnalysisProcess : public TRestEventProcess {
    protected:
     /// The pitch or size of the strips in mm
     Double_t fPitch;
+    /// Error assigned to the hits on the sides
+    Double_t fError;
 
    public:
     any GetInputEvent() const override { return fInputHitsEvent; }

--- a/inc/TRestDetectorHitsGaussAnalysisProcess.h
+++ b/inc/TRestDetectorHitsGaussAnalysisProcess.h
@@ -42,19 +42,19 @@ class TRestDetectorHitsGaussAnalysisProcess : public TRestEventProcess {
 
     void InitProcess() override;
 
-    void InitFromConfigFile() override;
-
     void Initialize() override;
 
     void LoadDefaultConfig();
 
    protected:
     /// The pitch or size of the strips in mm
-    Double_t fPitch;
+    Double_t fPitch = 0.5;
+
     /// Error assigned to the hits on the sides
-    Double_t fError;
+    Double_t fError = 150;
+
     /// The minimum number of hits required to apply the hit correction
-    Int_t fNHitsMin;
+    Int_t fNHitsMin = 100000;
 
    public:
     any GetInputEvent() const override { return fInputHitsEvent; }

--- a/inc/TRestDetectorHitsGaussAnalysisProcess.h
+++ b/inc/TRestDetectorHitsGaussAnalysisProcess.h
@@ -53,6 +53,8 @@ class TRestDetectorHitsGaussAnalysisProcess : public TRestEventProcess {
     Double_t fPitch;
     /// Error assigned to the hits on the sides
     Double_t fError;
+    /// The minimum number of hits required to apply the hit correction
+    Int_t fNHitsMin;
 
    public:
     any GetInputEvent() const override { return fInputHitsEvent; }

--- a/src/TRestDetectorHitsGaussAnalysisProcess.cxx
+++ b/src/TRestDetectorHitsGaussAnalysisProcess.cxx
@@ -161,9 +161,9 @@ TRestEvent* TRestDetectorHitsGaussAnalysisProcess::ProcessEvent(TRestEvent* inpu
         fOutputHitsEvent->AddHit(x, y, z, eDep, time, type);
     }
 
-    Double_t gausSigmaX = fOutputHitsEvent->GetGaussSigmaX(fError);
-    Double_t gausSigmaY = fOutputHitsEvent->GetGaussSigmaY(fError);
-    Double_t gausSigmaZ = fOutputHitsEvent->GetGaussSigmaZ(fError);
+    Double_t gausSigmaX = fOutputHitsEvent->GetGaussSigmaX(fError, fNHitsMin);
+    Double_t gausSigmaY = fOutputHitsEvent->GetGaussSigmaY(fError, fNHitsMin);
+    Double_t gausSigmaZ = fOutputHitsEvent->GetGaussSigmaZ(fError, fNHitsMin);
     Double_t xy2SigmaGaus = (gausSigmaX == -1. || gausSigmaY == -1.)
                                 ? -1.
                                 : (gausSigmaX * gausSigmaX) + (gausSigmaY * gausSigmaY);
@@ -198,6 +198,7 @@ TRestEvent* TRestDetectorHitsGaussAnalysisProcess::ProcessEvent(TRestEvent* inpu
 void TRestDetectorHitsGaussAnalysisProcess::InitFromConfigFile() {
     fPitch = StringToDouble(GetParameter("Pitch", "0.5"));
     fError = StringToDouble(GetParameter("Error", "150"));
+    fNHitsMin = StringToDouble(GetParameter("Error", "100000"));
 }
 
 ///////////////////////////////////////////////

--- a/src/TRestDetectorHitsGaussAnalysisProcess.cxx
+++ b/src/TRestDetectorHitsGaussAnalysisProcess.cxx
@@ -201,6 +201,7 @@ void TRestDetectorHitsGaussAnalysisProcess::PrintMetadata() {
     // Print output metadata using, metadata << endl;
     RESTMetadata << "Pitch (mm) : " << fPitch << RESTendl;
     RESTMetadata << "Error (ADC) : " << fError << RESTendl;
+    RESTMetadata << "Minimum number of hits to apply correction : " << fNHitsMin << RESTendl;
 
     EndPrintProcess();
 }

--- a/src/TRestDetectorHitsGaussAnalysisProcess.cxx
+++ b/src/TRestDetectorHitsGaussAnalysisProcess.cxx
@@ -161,9 +161,9 @@ TRestEvent* TRestDetectorHitsGaussAnalysisProcess::ProcessEvent(TRestEvent* inpu
         fOutputHitsEvent->AddHit(x, y, z, eDep, time, type);
     }
 
-    Double_t gausSigmaX = fOutputHitsEvent->GetGaussSigmaX();
-    Double_t gausSigmaY = fOutputHitsEvent->GetGaussSigmaY();
-    Double_t gausSigmaZ = fOutputHitsEvent->GetGaussSigmaZ();
+    Double_t gausSigmaX = fOutputHitsEvent->GetGaussSigmaX(fError);
+    Double_t gausSigmaY = fOutputHitsEvent->GetGaussSigmaY(fError);
+    Double_t gausSigmaZ = fOutputHitsEvent->GetGaussSigmaZ(fError);
     Double_t xy2SigmaGaus = (gausSigmaX == -1. || gausSigmaY == -1.)
                                 ? -1.
                                 : (gausSigmaX * gausSigmaX) + (gausSigmaY * gausSigmaY);
@@ -197,6 +197,7 @@ TRestEvent* TRestDetectorHitsGaussAnalysisProcess::ProcessEvent(TRestEvent* inpu
 ///
 void TRestDetectorHitsGaussAnalysisProcess::InitFromConfigFile() {
     fPitch = StringToDouble(GetParameter("Pitch", "0.5"));
+    fError = StringToDouble(GetParameter("Error", "150"));
 }
 
 ///////////////////////////////////////////////
@@ -208,6 +209,7 @@ void TRestDetectorHitsGaussAnalysisProcess::PrintMetadata() {
 
     // Print output metadata using, metadata << endl;
     RESTMetadata << "Pitch (mm) : " << fPitch << RESTendl;
+    RESTMetadata << "Error (ADC) : " << fError << RESTendl;
 
     EndPrintProcess();
 }

--- a/src/TRestDetectorHitsGaussAnalysisProcess.cxx
+++ b/src/TRestDetectorHitsGaussAnalysisProcess.cxx
@@ -192,16 +192,6 @@ TRestEvent* TRestDetectorHitsGaussAnalysisProcess::ProcessEvent(TRestEvent* inpu
 }
 
 ///////////////////////////////////////////////
-/// \brief Function reading input parameters from the RML
-/// TRestDetectorHitsGaussAnalysisProcess section
-///
-void TRestDetectorHitsGaussAnalysisProcess::InitFromConfigFile() {
-    fPitch = StringToDouble(GetParameter("Pitch", "0.5"));
-    fError = StringToDouble(GetParameter("Error", "150"));
-    fNHitsMin = StringToDouble(GetParameter("Error", "100000"));
-}
-
-///////////////////////////////////////////////
 /// \brief It prints out the process parameters stored in the
 /// metadata structure
 ///


### PR DESCRIPTION
![cmargalejo](https://badgen.net/badge/PR%20submitted%20by%3A/cmargalejo/blue) ![Ok: 21](https://badgen.net/badge/PR%20Size/Ok%3A%2021/green) [![](https://github.com/rest-for-physics/detectorlib/actions/workflows/validation.yml/badge.svg?branch=cris_hitsGaussError)](https://github.com/rest-for-physics/detectorlib/commits/cris_hitsGaussError)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

When fitting a gaussian to the hits, the error assigned to the external hits that are added at 0 ADC was hardcoded. Now the user can define it in the RML to match the expected value of the relevant detector, e.g.:  
`<parameter name="Error" value="200"/>`.
 This PR also needs https://github.com/rest-for-physics/framework/pull/428