### PR TITLE
Support arbitrary readout orientation

### DIFF
--- a/inc/TRestDetectorReadout.h
+++ b/inc/TRestDetectorReadout.h
@@ -74,8 +74,8 @@ class TRestDetectorReadout : public TRestMetadata {
     /////////////////////////////////////
     TRestDetectorReadoutModule* ParseModuleDefinition(TiXmlElement* moduleDefinition);
     void GetPlaneModuleChannel(Int_t daqID, Int_t& planeID, Int_t& moduleID, Int_t& channelID);
-    Int_t GetHitsDaqChannel(const TVector3& hitPosition, Int_t& planeID, Int_t& moduleID, Int_t& channelID);
-    Int_t GetHitsDaqChannelAtReadoutPlane(const TVector3& hitPosition, Int_t& moduleID, Int_t& channelID,
+    Int_t GetHitsDaqChannel(const TVector3& position, Int_t& planeID, Int_t& moduleID, Int_t& channelID);
+    Int_t GetHitsDaqChannelAtReadoutPlane(const TVector3& position, Int_t& moduleID, Int_t& channelID,
                                           Int_t planeId = 0);
     Double_t GetX(Int_t signalID);
     Double_t GetY(Int_t signalID);

--- a/inc/TRestDetectorReadoutModule.h
+++ b/inc/TRestDetectorReadoutModule.h
@@ -217,6 +217,7 @@ class TRestDetectorReadoutModule : public TObject {
     /// plane are inside this readout module.
     ///
     inline Bool_t isInside(Double_t x, Double_t y) { return isInside({x, y}); }
+    inline Bool_t isInside(const TVector3& position) const;
 
     Bool_t isInsideChannel(Int_t channel, Double_t x, Double_t y);
     Bool_t isInsideChannel(Int_t channel, const TVector2& position);
@@ -225,7 +226,7 @@ class TRestDetectorReadoutModule : public TObject {
     Bool_t isInsidePixel(Int_t channel, Int_t pixel, const TVector2& position);
 
     Bool_t isDaqIDInside(Int_t daqID);
-    Int_t FindChannel(Double_t x, Double_t y);
+    Int_t FindChannel(const TVector2& position);
     TVector2 GetDistanceToModule(const TVector2& position);
 
     TVector2 GetPixelOrigin(Int_t channel, Int_t pixel);

--- a/inc/TRestDetectorReadoutPlane.h
+++ b/inc/TRestDetectorReadoutPlane.h
@@ -42,11 +42,11 @@ class TRestDetectorReadoutPlane : public TObject {
 
     TVector3 fPosition;            ///< The position of the readout plane. The relative position
                                    ///< of the modules will be shifted by this value.
-    TVector3 fPlaneVector;         ///< The plane std::vector definning the plane orientation
+    TVector3 fPlaneVector;         ///< The plane std::vector defining the plane orientation
                                    ///< and the side of the active volume.
-    TVector3 fCathodePosition;     ///< The cathode position which delimites the active
+    TVector3 fCathodePosition;     ///< The cathode position which delimits the active
                                    ///< volume together with the readout plane.
-    Double_t fChargeCollection;    ///< A parameter between 0 and 1 definning how
+    Double_t fChargeCollection;    ///< A parameter between 0 and 1 defining how
                                    ///< much charge should be collected from a
                                    ///< charge hit. It might be used to distribute
                                    ///< the charge between different readout planes.

--- a/inc/TRestDetectorReadoutPlane.h
+++ b/inc/TRestDetectorReadoutPlane.h
@@ -147,7 +147,7 @@ class TRestDetectorReadoutPlane : public TObject {
 
     Bool_t isDaqIDInside(Int_t daqId);
 
-    Int_t GetModuleIDFromPosition(TVector3 pos);
+    Int_t GetModuleIDFromPosition(const TVector3& position);
 
     Int_t GetModuleIDFromPosition(Double_t x, Double_t y, Double_t z);
 

--- a/inc/TRestDetectorReadoutPlane.h
+++ b/inc/TRestDetectorReadoutPlane.h
@@ -68,15 +68,15 @@ class TRestDetectorReadoutPlane : public TObject {
     void SetID(int id) { fPlaneID = id; }
 
     /// Sets the readout plane position
-    void SetPosition(TVector3 pos) { fPosition = pos; }
+    void SetPosition(const TVector3& pos) { fPosition = pos; }
 
     /// Sets the cathode plane position. By default is parallel to the readout
     /// plane.
-    void SetCathodePosition(TVector3 pos) { fCathodePosition = pos; }
+    void SetCathodePosition(const TVector3& pos) { fCathodePosition = pos; }
 
     /// Sets the orientation of the readout plane, and defines the side of the
     /// active volume.
-    void SetPlaneVector(TVector3 vect) { fPlaneVector = vect.Unit(); }
+    void SetPlaneVector(const TVector3& vect) { fPlaneVector = vect.Unit(); }
 
     /// Sets the value for the charge collection.
     void SetChargeCollection(Double_t charge) { fChargeCollection = charge; }
@@ -105,7 +105,7 @@ class TRestDetectorReadoutPlane : public TObject {
 
     /// Returns the perpendicular distance to the readout plane from a given
     /// position *pos*.
-    Double_t GetDistanceTo(TVector3 pos);
+    Double_t GetDistanceTo(const TVector3& pos);
 
     /// Returns the perpendicular distance to the readout plane from a given
     /// position *x*, *y*, *z*.
@@ -113,7 +113,7 @@ class TRestDetectorReadoutPlane : public TObject {
 
     /// Returns a TVector2 oriented as the shortest distance of a given position
     /// *pos* on the plane to a specific module with id *mod*
-    TVector2 GetDistanceToModule(Int_t mod, TVector2 pos) {
+    TVector2 GetDistanceToModule(Int_t mod, const TVector2& pos) {
         return GetModuleByID(mod)->GetDistanceToModule(pos);
     }
 
@@ -143,13 +143,11 @@ class TRestDetectorReadoutPlane : public TObject {
 
     Int_t isZInsideDriftVolume(Double_t z);
 
-    Int_t isZInsideDriftVolume(TVector3 pos);
+    Int_t isZInsideDriftVolume(const TVector3& pos);
 
     Bool_t isDaqIDInside(Int_t daqId);
 
     Int_t GetModuleIDFromPosition(const TVector3& position);
-
-    Int_t GetModuleIDFromPosition(Double_t x, Double_t y, Double_t z);
 
     void SetDriftDistance();
 

--- a/inc/TRestDetectorReadoutPlane.h
+++ b/inc/TRestDetectorReadoutPlane.h
@@ -117,6 +117,8 @@ class TRestDetectorReadoutPlane : public TObject {
         return GetModuleByID(mod)->GetDistanceToModule(pos);
     }
 
+    TVector2 GetRelativePosition(const TVector3& pos) const;
+
     TRestDetectorReadoutModule& operator[](int mod) { return fReadoutModules[mod]; }
 
     /// Returns a pointer to a readout module using its std::vector index

--- a/src/TRestDetectorHitsToSignalProcess.cxx
+++ b/src/TRestDetectorHitsToSignalProcess.cxx
@@ -230,7 +230,7 @@ TRestEvent* TRestDetectorHitsToSignalProcess::ProcessEvent(TRestEvent* inputEven
 
         for (int p = 0; p < fReadout->GetNumberOfReadoutPlanes(); p++) {
             Int_t daqId =
-                fReadout->GetHitsDaqChannelAtReadoutPlane(TVector3(x, y, z), moduleId, channelId, p);
+                fReadout->GetHitsDaqChannelAtReadoutPlane({x, y, z}, moduleId, channelId, p);
 
             TRestDetectorReadoutPlane* plane = fReadout->GetReadoutPlaneWithID(p);
 

--- a/src/TRestDetectorReadout.cxx
+++ b/src/TRestDetectorReadout.cxx
@@ -748,7 +748,7 @@ void TRestDetectorReadout::GetPlaneModuleChannel(Int_t signalID, Int_t& planeID,
     }
 }
 
-Int_t TRestDetectorReadout::GetHitsDaqChannel(const TVector3& hitpos, Int_t& planeID, Int_t& moduleID,
+Int_t TRestDetectorReadout::GetHitsDaqChannel(const TVector3& position, Int_t& planeID, Int_t& moduleID,
                                               Int_t& channelID) {
     for (int p = 0; p < GetNumberOfReadoutPlanes(); p++) {
         TRestDetectorReadoutPlane* plane = &fReadoutPlanes[p];
@@ -773,7 +773,7 @@ Int_t TRestDetectorReadout::GetHitsDaqChannel(const TVector3& hitpos, Int_t& pla
 /// \return the value of the daq id corresponding to the readout channel
 //
 ///
-Int_t TRestDetectorReadout::GetHitsDaqChannelAtReadoutPlane(const TVector3& hitpos, Int_t& moduleID,
+Int_t TRestDetectorReadout::GetHitsDaqChannelAtReadoutPlane(const TVector3& position, Int_t& moduleID,
                                                             Int_t& channelID, Int_t planeId) {
     if (planeId > GetNumberOfReadoutPlanes()) {
         RESTWarning << "TRestDetectorReadout. Fail trying to retrieve planeId : " << planeId << RESTendl;
@@ -782,10 +782,11 @@ Int_t TRestDetectorReadout::GetHitsDaqChannelAtReadoutPlane(const TVector3& hitp
     }
 
     TRestDetectorReadoutPlane* plane = &fReadoutPlanes[planeId];
-    int m = plane->GetModuleIDFromPosition(hitpos.X(), hitpos.Y(), hitpos.Z());
+    int m = plane->GetModuleIDFromPosition(position);
     if (m >= 0) {
         TRestDetectorReadoutModule* mod = plane->GetModuleByID(m);
-        Int_t readoutChannel = mod->FindChannel(hitpos.X(), hitpos.Y());
+        const TVector2 relativePosition = plane->GetRelativePosition(position);
+        Int_t readoutChannel = mod->FindChannel(relativePosition);
         if (readoutChannel >= 0) {
             moduleID = mod->GetModuleID();
             channelID = readoutChannel;

--- a/src/TRestDetectorReadout.cxx
+++ b/src/TRestDetectorReadout.cxx
@@ -752,17 +752,9 @@ Int_t TRestDetectorReadout::GetHitsDaqChannel(const TVector3& hitpos, Int_t& pla
                                               Int_t& channelID) {
     for (int p = 0; p < GetNumberOfReadoutPlanes(); p++) {
         TRestDetectorReadoutPlane* plane = &fReadoutPlanes[p];
-        int m = plane->GetModuleIDFromPosition(hitpos.X(), hitpos.Y(), hitpos.Z());
+        int m = plane->GetModuleIDFromPosition(position);
         if (m >= 0) {
-            // TRestDetectorReadoutModule* mod = plane->GetModuleByID(m);
-            TRestDetectorReadoutModule* mod = plane->GetModuleByID(m);
-            Int_t readoutChannel = mod->FindChannel(hitpos.X(), hitpos.Y());
-            if (readoutChannel >= 0) {
-                planeID = plane->GetID();
-                moduleID = mod->GetModuleID();
-                channelID = readoutChannel;
-                return mod->GetChannel(readoutChannel)->GetDaqID();
-            }
+            return GetHitsDaqChannelAtReadoutPlane(position, moduleID, channelID, p);
         }
     }
     return -1;

--- a/src/TRestDetectorReadout.cxx
+++ b/src/TRestDetectorReadout.cxx
@@ -146,7 +146,7 @@
 /// and the daq channel number defined at the acquisition system.
 /// If *no decoding* file is defined the relation between daq and readout
 /// channel is assigned *one to one*.
-/// The decoding file must be a text file definning two columns with as
+/// The decoding file must be a text file defining two columns with as
 /// many columns as the number of channels defined in the readout module.
 /// The first column is the daq channel number, and the second column is
 /// the readout channel defined in the RML file.

--- a/src/TRestDetectorReadoutModule.cxx
+++ b/src/TRestDetectorReadoutModule.cxx
@@ -231,7 +231,10 @@ Bool_t TRestDetectorReadoutModule::isDaqIDInside(Int_t daqID) {
 /// The readout mapping (see TRestDetectorReadoutMapping) is used to help finding
 /// the pixel where coordinates absX and absY fall in.
 ///
-Int_t TRestDetectorReadoutModule::FindChannel(Double_t absX, Double_t absY) {
+Int_t TRestDetectorReadoutModule::FindChannel(const TVector2& position) {
+    const auto& absX = position.X();
+    const auto& absY = position.Y();
+
     if (!isInside(absX, absY)) return -1;
 
     Double_t x = TransformToModuleCoordinates(absX, absY).X();
@@ -325,9 +328,11 @@ Int_t TRestDetectorReadoutModule::FindChannel(Double_t absX, Double_t absY) {
 Bool_t TRestDetectorReadoutModule::isInside(const TVector2& position) {
     TVector2 rotPos = TransformToModuleCoordinates(position);
 
-    if (rotPos.X() >= 0 && rotPos.X() < fModuleSizeX)
-        if (rotPos.Y() >= 0 && rotPos.Y() < fModuleSizeY) return true;
-
+    if (rotPos.X() >= 0 && rotPos.X() < fModuleSizeX) {
+        if (rotPos.Y() >= 0 && rotPos.Y() < fModuleSizeY) {
+            return true;
+        }
+    }
     return false;
 }
 

--- a/src/TRestDetectorReadoutModule.cxx
+++ b/src/TRestDetectorReadoutModule.cxx
@@ -408,7 +408,7 @@ TVector2 TRestDetectorReadoutModule::GetPixelOrigin(Int_t channel, Int_t pixel) 
 /// \brief Returns any of the pixel vertex position for a given *channel* and
 /// *pixel* indexes.
 ///
-/// \param vertex A value between 0-3 definning the vertex position to be
+/// \param vertex A value between 0-3 defining the vertex position to be
 /// returned
 ///
 TVector2 TRestDetectorReadoutModule::GetPixelVertex(Int_t channel, Int_t pixel, Int_t vertex) {
@@ -423,7 +423,7 @@ TVector2 TRestDetectorReadoutModule::GetPixelVertex(Int_t channel, Int_t pixel, 
 /// \brief Returns the center pixel position for a given *channel* and
 /// *pixel* indexes.
 ///
-/// \param vertex A value between 0-3 definning the vertex position to be
+/// \param vertex A value between 0-3 defining the vertex position to be
 /// returned
 ///
 TVector2 TRestDetectorReadoutModule::GetPixelCenter(Int_t channel, Int_t pixel) {
@@ -474,7 +474,7 @@ Bool_t TRestDetectorReadoutModule::GetPixelTriangle(TRestDetectorReadoutPixel* p
 /// physical coordinates relative to the readout plane are returned, including
 /// rotation.
 ///
-/// \param n A value between 0-3 definning the vertex position to be returned
+/// \param n A value between 0-3 defining the vertex position to be returned
 ///
 TVector2 TRestDetectorReadoutModule::GetVertex(int n) const {
     TVector2 vertex(0, 0);

--- a/src/TRestDetectorReadoutPixel.cxx
+++ b/src/TRestDetectorReadoutPixel.cxx
@@ -81,7 +81,7 @@ TVector2 TRestDetectorReadoutPixel::GetCenter() const {
 ///////////////////////////////////////////////
 /// \brief Returns the specified pixel vertex position
 ///
-/// \param n A value between 0-3 definning the vertex position to be returned.
+/// \param n A value between 0-3 defining the vertex position to be returned.
 ///
 TVector2 TRestDetectorReadoutPixel::GetVertex(int n) const {
     TVector2 vertex(0, 0);

--- a/src/TRestDetectorReadoutPlane.cxx
+++ b/src/TRestDetectorReadoutPlane.cxx
@@ -446,3 +446,14 @@ void TRestDetectorReadoutPlane::GetBoundaries(double& xmin, double& xmax, double
         }
     }
 }
+
+
+///////////////////////////////////////////////
+/// \brief Rotates the point with the direction of the readout plane.
+///
+TVector2 TRestDetectorReadoutPlane::GetRelativePosition(const TVector3& position) const {
+    TVector3 rotated = position;
+    rotated.RotateUz(fPlaneVector);
+
+    return {rotated.X(), rotated.Y()};
+}

--- a/src/TRestDetectorReadoutPlane.cxx
+++ b/src/TRestDetectorReadoutPlane.cxx
@@ -250,7 +250,7 @@ Int_t TRestDetectorReadoutPlane::FindChannel(Int_t module, Double_t absX, Double
     // FindChannel will take a long time to search for the channel if it is not
     // there. It will be faster
 
-    return fReadoutModules[module].FindChannel(modX, modY);
+    return fReadoutModules[module].FindChannel({modX, modY});
 }
 
 ///////////////////////////////////////////////
@@ -265,7 +265,7 @@ Double_t TRestDetectorReadoutPlane::GetDistanceTo(Double_t x, Double_t y, Double
 /// \brief Returns the perpendicular distance to the readout plane of a given
 /// TVector3 position
 ///
-Double_t TRestDetectorReadoutPlane::GetDistanceTo(TVector3 pos) {
+Double_t TRestDetectorReadoutPlane::GetDistanceTo(const TVector3& pos) {
     return (pos - GetPosition()).Dot(GetPlaneVector());
 }
 
@@ -305,7 +305,7 @@ Bool_t TRestDetectorReadoutPlane::isDaqIDInside(Int_t daqId) {
 /// \return 1 if the Z-position is found inside the drift volume definition. 0
 /// otherwise
 ///
-Int_t TRestDetectorReadoutPlane::isZInsideDriftVolume(TVector3 pos) {
+Int_t TRestDetectorReadoutPlane::isZInsideDriftVolume(const TVector3& pos) {
     TVector3 posNew = TVector3(pos.X() - fPosition.X(), pos.Y() - fPosition.Y(), pos.Z());
 
     Double_t distance = GetDistanceTo(posNew);
@@ -326,11 +326,7 @@ Int_t TRestDetectorReadoutPlane::isZInsideDriftVolume(TVector3 pos) {
 /// \return the module *id* where the hit is found. If no module *id* is found
 /// it returns -1.
 ///
-Int_t TRestDetectorReadoutPlane::GetModuleIDFromPosition(Double_t x, Double_t y, Double_t z) {
-    TVector3 pos = TVector3(x, y, z);
 
-    return GetModuleIDFromPosition(pos);
-}
 ///////////////////////////////////////////////
 /// \brief This method returns the module id where *pos* is found.
 /// The z-coordinate must be found in between

--- a/src/TRestDetectorReadoutPlane.cxx
+++ b/src/TRestDetectorReadoutPlane.cxx
@@ -342,14 +342,17 @@ Int_t TRestDetectorReadoutPlane::GetModuleIDFromPosition(Double_t x, Double_t y,
 /// \return the module *id* where the hit is found. If no module *id* is found
 /// it returns -1.
 ///
-Int_t TRestDetectorReadoutPlane::GetModuleIDFromPosition(TVector3 pos) {
-    TVector3 posNew = TVector3(pos.X() - fPosition.X(), pos.Y() - fPosition.Y(), pos.Z());
+Int_t TRestDetectorReadoutPlane::GetModuleIDFromPosition(const TVector3& position) {
+    TVector3 posNew = TVector3(position.X() - fPosition.X(), position.Y() - fPosition.Y(), position.Z());
 
     Double_t distance = GetDistanceTo(posNew);
 
     if (distance > 0 && distance < fTotalDriftDistance) {
-        for (int m = 0; m < GetNumberOfModules(); m++)
-            if (fReadoutModules[m].isInside(posNew.X(), posNew.Y())) return fReadoutModules[m].GetModuleID();
+        for (auto& module : fReadoutModules) {
+            if (module.isInside(posNew.X(), posNew.Y())) {
+                return module.GetModuleID();
+            }
+        }
     }
 
     return -1;

--- a/src/TRestDetectorReadoutPlane.cxx
+++ b/src/TRestDetectorReadoutPlane.cxx
@@ -155,7 +155,7 @@ Double_t TRestDetectorReadoutPlane::GetX(Int_t modID, Int_t chID) {
                 if (deltaY < deltaX) x = rModule->GetPixelCenter(chID, 0).X();
             }
         } else {
-            // we choose to ouput x only when deltaY > deltaX under non-90 deg rotation
+            // we choose to output x only when deltaY > deltaX under non-90 deg rotation
             // otherwise it is a y channel and should return nan
             if (deltaY > deltaX) x = rModule->GetPixelCenter(chID, 0).X();
         }
@@ -225,7 +225,7 @@ Double_t TRestDetectorReadoutPlane::GetY(Int_t modID, Int_t chID) {
                 if (deltaY > deltaX) y = rModule->GetPixelCenter(chID, 0).Y();
             }
         } else {
-            // we choose to ouput y only when deltaY < deltaX under non-90 deg rotation
+            // we choose to output y only when deltaY < deltaX under non-90 deg rotation
             // otherwise it is a x channel and should return nan
             if (deltaY < deltaX) y = rModule->GetPixelCenter(chID, 0).Y();
         }
@@ -300,7 +300,7 @@ Bool_t TRestDetectorReadoutPlane::isDaqIDInside(Int_t daqId) {
 /// \brief This method determines if the z-coordinate is inside the drift volume
 /// for this readout plane.
 ///
-/// \param pos A TVector3 definning the position.
+/// \param pos A TVector3 defining the position.
 ///
 /// \return 1 if the Z-position is found inside the drift volume definition. 0
 /// otherwise
@@ -321,7 +321,7 @@ Int_t TRestDetectorReadoutPlane::isZInsideDriftVolume(TVector3 pos) {
 /// the readout plane. The *x* and *y* values must be found inside one of the
 /// readout modules defined inside the readout plane.
 ///
-/// \param x,y,z Three Double_t definning the position.
+/// \param x,y,z Three Double_t defining the position.
 ///
 /// \return the module *id* where the hit is found. If no module *id* is found
 /// it returns -1.
@@ -337,7 +337,7 @@ Int_t TRestDetectorReadoutPlane::GetModuleIDFromPosition(Double_t x, Double_t y,
 /// the cathode and the readout plane. The *x* and *y* values must be found
 /// inside one of the readout modules defined inside the readout plane.
 ///
-/// \param pos A TVector3 definning the position.
+/// \param position A TVector3 defining the position.
 ///
 /// \return the module *id* where the hit is found. If no module *id* is found
 /// it returns -1.


### PR DESCRIPTION
Currently the readout plane only works correctly if the orientation is in the z direction.