### PR TITLE
Adding cache detectorlib installation

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -61,6 +61,12 @@ jobs:
         run: |
           source ${{ env.REST_PATH }}/thisREST.sh
           restRoot -b -q
+      - name: Cache framework installation
+        id: detectorlib-install-cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ env.BRANCH_NAME }}-${{ github.sha }}
+          path: ${{ env.REST_PATH }}
 
   readout:
     name: "Readout"


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 6](https://badgen.net/badge/PR%20Size/Ok%3A%206/green) [![](https://github.com/rest-for-physics/detectorlib/actions/workflows/validation.yml/badge.svg?branch=jgalan-pipeline-fix)](https://github.com/rest-for-physics/detectorlib/commits/jgalan-pipeline-fix)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The pipeline is failing because it does not find detectorlib installation.

See for example: https://github.com/rest-for-physics/axionlib/actions/runs/5175275109/jobs/9322828807?pr=69

The change in detectorlib validation pipeline does not take place till this PR will be merged. So we need to merge to do the test.

I implemented it inspired on the implementation of pipeline at rawlib