### PR TITLE
Update hits rotation

### DIFF
--- a/inc/TRestDetectorHitsRotateAndTranslateProcess.h
+++ b/inc/TRestDetectorHitsRotateAndTranslateProcess.h
@@ -26,13 +26,9 @@ class TRestDetectorHitsRotateAndTranslateProcess : public TRestEventProcess {
     TRestDetectorHitsEvent* fInputHitsEvent;   //!
     TRestDetectorHitsEvent* fOutputHitsEvent;  //!
 
-    Double_t fDeltaX;  ///< shift in X-axis
-    Double_t fDeltaY;  ///< shift in X-axis
-    Double_t fDeltaZ;  ///< shift in X-axis
-
-    Double_t fAlpha;  ///< rotation angle around z-axis
-    Double_t fBeta;   ///< rotation angle around y-axis
-    Double_t fGamma;  ///< rotation angle around x-axis
+    TVector3 fTranslationVector = {0, 0, 0};  ///< translation vector (x,y,z)
+    TVector3 fRotationVector = {0, 0, 0};     ///< rotation vector around axis (x,y,z) in radians
+    TVector3 fRotationCenter = {0, 0, 0};     ///< rotation center (x,y,z)
 
     void InitFromConfigFile() override;
     void Initialize() override;
@@ -49,39 +45,35 @@ class TRestDetectorHitsRotateAndTranslateProcess : public TRestEventProcess {
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;
     void EndProcess() override;
 
-    void LoadConfig(std::string configFilename);
+    void LoadConfig(const std::string& configFilename);
 
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        RESTMetadata << " delta x : " << fDeltaX << RESTendl;
-        RESTMetadata << " delta y : " << fDeltaY << RESTendl;
-        RESTMetadata << " delta z : " << fDeltaZ << RESTendl;
-        RESTMetadata << " alpha : " << fAlpha << RESTendl;
-        RESTMetadata << " beta : " << fBeta << RESTendl;
-        RESTMetadata << " gamma : " << fGamma << RESTendl;
+        RESTMetadata << "Translation vector (mm): (" << fTranslationVector.X() << ", "
+                     << fTranslationVector.Y() << ", " << fTranslationVector.Z() << ")" << RESTendl;
+        TVector3 rotationVectorDegrees = fRotationVector * (180. / TMath::Pi());
+        RESTMetadata << "Rotation vector (degrees): (" << rotationVectorDegrees.X() << ", "
+                     << rotationVectorDegrees.Y() << ", " << rotationVectorDegrees.Z() << ")" << RESTendl;
 
         EndPrintProcess();
     }
 
-    const char* GetProcessName() const override { return "rotateAndTraslate"; }
+    const char* GetProcessName() const override { return "rotateAndTranslate"; }
 
-    inline Double_t GetDeltaX() const { return fDeltaX; }
-    inline Double_t GetDeltaY() const { return fDeltaY; }
-    inline Double_t GetDeltaZ() const { return fDeltaZ; }
+    inline Double_t GetTranslationX() const { return fTranslationVector.X(); }
+    inline Double_t GetTranslationY() const { return fTranslationVector.Y(); }
+    inline Double_t GetTranslationZ() const { return fTranslationVector.Z(); }
 
-    inline Double_t GetAlpha() const { return fAlpha; }
-    inline Double_t GetBeta() const { return fBeta; }
-    inline Double_t GetGamma() const { return fGamma; }
+    inline Double_t GetRotationX() const { return fRotationVector.X(); }
+    inline Double_t GetRotationY() const { return fRotationVector.Y(); }
+    inline Double_t GetRotationZ() const { return fRotationVector.Z(); }
 
-    // Constructor
     TRestDetectorHitsRotateAndTranslateProcess();
-    TRestDetectorHitsRotateAndTranslateProcess(const char* configFilename);
-    // Destructor
+    explicit TRestDetectorHitsRotateAndTranslateProcess(const char* configFilename);
     ~TRestDetectorHitsRotateAndTranslateProcess();
 
-    ClassDefOverride(TRestDetectorHitsRotateAndTranslateProcess,
-                     1);  // Template for a REST "event process" class inherited from
-                          // TRestEventProcess
+    ClassDefOverride(TRestDetectorHitsRotateAndTranslateProcess, 2);
 };
+
 #endif

--- a/src/TRestDetectorHitsRotateAndTranslateProcess.cxx
+++ b/src/TRestDetectorHitsRotateAndTranslateProcess.cxx
@@ -40,89 +40,78 @@ TRestDetectorHitsRotateAndTranslateProcess::TRestDetectorHitsRotateAndTranslateP
     PrintMetadata();
 }
 
-TRestDetectorHitsRotateAndTranslateProcess::~TRestDetectorHitsRotateAndTranslateProcess() {
-    // TRestDetectorHitsRotateAndTranslateProcess destructor
-}
+TRestDetectorHitsRotateAndTranslateProcess::~TRestDetectorHitsRotateAndTranslateProcess() = default;
 
-void TRestDetectorHitsRotateAndTranslateProcess::LoadDefaultConfig() {
-    SetTitle("Default config");
-
-    fDeltaX = 1.0;
-    fDeltaY = 1.0;
-    fDeltaZ = 1.0;
-    fAlpha = 0.;
-    fBeta = 0.;
-    fGamma = 0.;
-}
+void TRestDetectorHitsRotateAndTranslateProcess::LoadDefaultConfig() { SetTitle("Default config"); }
 
 void TRestDetectorHitsRotateAndTranslateProcess::Initialize() {
     SetSectionName(this->ClassName());
     SetLibraryVersion(LIBRARY_VERSION);
 
-    fDeltaX = 1.0;
-    fDeltaY = 1.0;
-    fDeltaZ = 1.0;
-    fAlpha = 0.;
-    fBeta = 0.;
-    fGamma = 0.;
-
     fInputHitsEvent = nullptr;
     fOutputHitsEvent = nullptr;
+
+    // Get volume name from parameter
 }
 
-void TRestDetectorHitsRotateAndTranslateProcess::LoadConfig(string configFilename) {
-    if (LoadConfigFromFile(configFilename)) LoadDefaultConfig();
+void TRestDetectorHitsRotateAndTranslateProcess::LoadConfig(const string& configFilename) {
+    if (LoadConfigFromFile(configFilename)) {
+        LoadDefaultConfig();
+    }
 
     PrintMetadata();
 }
 
-void TRestDetectorHitsRotateAndTranslateProcess::InitProcess() {
-    // Function to be executed once at the beginning of process
-    // (before starting the process of the events)
-
-    // Start by calling the InitProcess function of the abstract class.
-    // Comment this if you don't want it.
-    // TRestEventProcess::InitProcess();
-}
+void TRestDetectorHitsRotateAndTranslateProcess::InitProcess() {}
 
 TRestEvent* TRestDetectorHitsRotateAndTranslateProcess::ProcessEvent(TRestEvent* inputEvent) {
     fInputHitsEvent = (TRestDetectorHitsEvent*)inputEvent;
-
     fOutputHitsEvent = fInputHitsEvent;
-    // fInputHitsEvent->CloneTo(fOutputHitsEvent);
 
-    TVector3 meanPosition = fOutputHitsEvent->GetMeanPosition();
-    for (unsigned int hit = 0; hit < fOutputHitsEvent->GetNumberOfHits(); hit++) {
-        fOutputHitsEvent->GetHits()->RotateIn3D(hit, fAlpha, fBeta, fGamma, meanPosition);
-        fOutputHitsEvent->GetHits()->Translate(hit, fDeltaX, fDeltaY, fDeltaZ);
+    if (fOutputHitsEvent->GetNumberOfHits() == 0) {
+        return nullptr;
     }
 
-    if (fOutputHitsEvent->GetNumberOfHits() == 0) return nullptr;
+    for (unsigned int hit = 0; hit < fOutputHitsEvent->GetNumberOfHits(); hit++) {
+        const auto& type = fOutputHitsEvent->GetHits()->GetType(hit);
+        if (type == VETO) {
+            // Do not rotate VETO hits (we typically only rotate TPC hits)
+            continue;
+        }
+        fOutputHitsEvent->GetHits()->RotateIn3D(hit, fRotationVector.X(), fRotationVector.Y(),
+                                                fRotationVector.Z(), fRotationCenter);
+        fOutputHitsEvent->GetHits()->Translate(hit, fTranslationVector.X(), fTranslationVector.Y(),
+                                               fTranslationVector.Z());
+    }
 
-    RESTDebug << "Number of hits rotated: " << fInputHitsEvent->GetNumberOfHits() << RESTendl;
     return fOutputHitsEvent;
 }
 
-void TRestDetectorHitsRotateAndTranslateProcess::EndProcess() {
-    // Function to be executed once at the end of the process
-    // (after all events have been processed)
-
-    // Start by calling the EndProcess function of the abstract class.
-    // Comment this if you don't want it.
-    // TRestEventProcess::EndProcess();
-}
+void TRestDetectorHitsRotateAndTranslateProcess::EndProcess() {}
 
 void TRestDetectorHitsRotateAndTranslateProcess::InitFromConfigFile() {
-    fDeltaX = GetDblParameterWithUnits("deltaX");
-    fDeltaY = GetDblParameterWithUnits("deltaY");
-    fDeltaZ = GetDblParameterWithUnits("deltaZ");
+    fRotationCenter = Get3DVectorParameterWithUnits("rotationCenter", fRotationCenter);
+    fTranslationVector = Get3DVectorParameterWithUnits("translation", fTranslationVector);
 
-    fAlpha = StringToDouble(GetParameter("alpha"));  // rotation angle around Z
-    fBeta = StringToDouble(GetParameter("beta"));    // rotation angle around Y
-    fGamma = StringToDouble(GetParameter("gamma"));  // rotation angle around X
+    // rotation units should be specified in the rml (e.g. "90deg")
+    double rotationX = GetDblParameterWithUnits("rotationX", fRotationVector.X());
+    double rotationY = GetDblParameterWithUnits("rotationY", fRotationVector.Y());
+    double rotationZ = GetDblParameterWithUnits("rotationZ", fRotationVector.Z());
+    fRotationVector = {rotationX, rotationY, rotationZ};
 
-    // Conversion to radians
-    fAlpha = fAlpha * TMath::Pi() / 180.;
-    fBeta = fBeta * TMath::Pi() / 180.;
-    fGamma = fGamma * TMath::Pi() / 180.;
+    // legacy (maybe deprecated soon)
+    if (fTranslationVector.Mag2() == 0) {
+        fTranslationVector = {
+            GetDblParameterWithUnits("deltaX", 0),  //
+            GetDblParameterWithUnits("deltaY", 0),  //
+            GetDblParameterWithUnits("deltaZ", 0),  //
+        };
+    }
+    if (fRotationVector.Mag2() == 0) {
+        fRotationVector = {
+            GetDblParameterWithUnits("alpha", 0),  //
+            GetDblParameterWithUnits("beta", 0),   //
+            GetDblParameterWithUnits("gamma", 0),  //
+        };
+    }
 }

--- a/src/TRestDetectorHitsRotateAndTranslateProcess.cxx
+++ b/src/TRestDetectorHitsRotateAndTranslateProcess.cxx
@@ -19,6 +19,20 @@
 ///                 Javier G. Garza
 ///_______________________________________________________________________________
 
+//////////////////////////////////////////////////////////////////////////
+///
+/// This process rotates and translates hits in a TRestDetectorHitsEvent.
+/// Hits of type "VETO" are not affected by this process (we typically only want to rotate TPC hits).
+///
+/// Usage:
+///
+///    <addProcess type="TRestDetectorHitsRotateAndTranslateProcess">
+///        <parameter name="rotationCenter" value="(0,0,0)mm" />
+///        <parameter name="translation" value="(0,10,0)mm" />
+///        <parameter name="rotationZ" value="45deg" />
+///    </addProcess>
+///
+
 #include "TRestDetectorHitsRotateAndTranslateProcess.h"
 
 using namespace std;

--- a/src/TRestDetectorHitsRotateAndTranslateProcess.cxx
+++ b/src/TRestDetectorHitsRotateAndTranslateProcess.cxx
@@ -37,8 +37,6 @@
 
 using namespace std;
 
-#include <TRandom3.h>
-
 ClassImp(TRestDetectorHitsRotateAndTranslateProcess);
 
 TRestDetectorHitsRotateAndTranslateProcess::TRestDetectorHitsRotateAndTranslateProcess() { Initialize(); }

--- a/src/TRestDetectorHitsRotateAndTranslateProcess.cxx
+++ b/src/TRestDetectorHitsRotateAndTranslateProcess.cxx
@@ -114,18 +114,18 @@ void TRestDetectorHitsRotateAndTranslateProcess::InitFromConfigFile() {
     fRotationVector = {rotationX, rotationY, rotationZ};
 
     // legacy (maybe deprecated soon)
-    if (fTranslationVector.Mag2() == 0) {
+    if (fTranslationVector.Mag2() == 0.0) {
         fTranslationVector = {
-            GetDblParameterWithUnits("deltaX", 0),  //
-            GetDblParameterWithUnits("deltaY", 0),  //
-            GetDblParameterWithUnits("deltaZ", 0),  //
+            GetDblParameterWithUnits("deltaX", 0.0),  //
+            GetDblParameterWithUnits("deltaY", 0.0),  //
+            GetDblParameterWithUnits("deltaZ", 0.0),  //
         };
     }
-    if (fRotationVector.Mag2() == 0) {
+    if (fRotationVector.Mag2() == 0.0) {
         fRotationVector = {
-            GetDblParameterWithUnits("alpha", 0),  //
-            GetDblParameterWithUnits("beta", 0),   //
-            GetDblParameterWithUnits("gamma", 0),  //
+            GetDblParameterWithUnits("alpha", 0.0),  //
+            GetDblParameterWithUnits("beta", 0.0),   //
+            GetDblParameterWithUnits("gamma", 0.0),  //
         };
     }
 }


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 80](https://badgen.net/badge/PR%20Size/Ok%3A%2080/green) [![](https://github.com/rest-for-physics/detectorlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=lobis-hits-rotation)](https://github.com/rest-for-physics/detectorlib/commits/lobis-hits-rotation)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Update hits rotation inside detectorlib:

- Alternative (more clean IMHO) way to set parameters in the rml. Old syntax still works:

```
<addProcess type="TRestDetectorHitsRotateAndTranslateProcess">
      <parameter name="rotationCenter" value="(0,0,0)mm" />
      <parameter name="translation" value="(0,10,0)mm" />
      <parameter name="rotationZ" value="45deg" />
</addProcess>
```

- New parameter "rotationCenter" to specify the rotation center (defaults to (0,0,0)). **Before the hits were rotation around the mean position of the hits, which does not make much sense to me as a default behaviour and this was not modifiable by the user. I was not aware of this until I looked at the code, perhaps others such as @cmargalejo are also unaware (because you mentioned to rotate the hits for the 45º rotated readout in the iaxo setup, those rotations were not done properly).**

- Do not rotate especial (veto) hits. Because this process will mostly be used on TPC hits but we need to keep other hits such as veto hits, I put an explicit ignore for veto hits. This is not very clean but it works, we should probably think of a better strategy in the future to handle multiple types of "events in a single event (veto / tpc)".
