### PR TITLE
Update TRestDetectorHitsEventViewer.cxx

### DIFF
--- a/src/TRestDetectorHitsEventViewer.cxx
+++ b/src/TRestDetectorHitsEventViewer.cxx
@@ -52,7 +52,7 @@ void TRestDetectorHitsEventViewer::AddEvent(TRestEvent* ev) {
     }
 
     Double_t slope;
-    if (eDepMin == eDepMin)
+    if (eDepMin == eDepMax)
         slope = 0;
     else
         slope = (fMaxRadius - fMinRadius) / (eDepMax - eDepMin);


### PR DESCRIPTION
Seems like there was a typo in the "slope" definition, it was always =0 with the previous definition.

- Definition corrected