### PR TITLE
Fix negative time due to overflow

### DIFF
--- a/src/TRestDetectorHitsToSignalProcess.cxx
+++ b/src/TRestDetectorHitsToSignalProcess.cxx
@@ -287,7 +287,8 @@ TRestEvent* TRestDetectorHitsToSignalProcess::ProcessEvent(TRestEvent* inputEven
                 if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) {
                     cout << "Drift velocity : " << fDriftVelocity << " mm/us" << endl;
                 }
-                time = ((Int_t)(time / fSampling)) * fSampling;  // now time is in unit "us", but dispersed
+
+                time = floor(time / fSampling) * fSampling;
 
                 fSignalEvent->AddChargeToSignal(daqId, time, energy);
 


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 2](https://badgen.net/badge/PR%20Size/Ok%3A%202/green) [![](https://github.com/rest-for-physics/detectorlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=lobis-fix-negative-times)](https://github.com/rest-for-physics/detectorlib/commits/lobis-fix-negative-times) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Some large times in the geant4 simulation were being converted into negative due to overflow.