### PR TITLE
TRestRawSignal - Use double for storage instead of float

### DIFF
--- a/inc/TRestDetectorSignal.h
+++ b/inc/TRestDetectorSignal.h
@@ -37,8 +37,8 @@ class TRestDetectorSignal {
    protected:
     Int_t fSignalID = -1;
 
-    std::vector<Float_t> fSignalTime;    // Vector with the time of the signal
-    std::vector<Float_t> fSignalCharge;  // Vector with the charge of the signal
+    std::vector<Double_t> fSignalTime;    // Vector with the time of the signal
+    std::vector<Double_t> fSignalCharge;  // Vector with the charge of the signal
 
     // TODO: remove this and use readout
     std::string fName;  // Name of the signal
@@ -121,7 +121,7 @@ class TRestDetectorSignal {
     void SetSignalID(Int_t sID) { fSignalID = sID; }
     void SetID(Int_t sID) { fSignalID = sID; }
 
-    void NewPoint(Float_t time, Float_t data);
+    void NewPoint(Double_t time, Double_t data);
     void IncreaseAmplitude(Double_t t, Double_t d);
 
     void SetPoint(Double_t t, Double_t d);
@@ -167,6 +167,6 @@ class TRestDetectorSignal {
     // Destructor
     ~TRestDetectorSignal();
 
-    ClassDef(TRestDetectorSignal, 3);
+    ClassDef(TRestDetectorSignal, 4);
 };
 #endif

--- a/inc/TRestDetectorSignal.h
+++ b/inc/TRestDetectorSignal.h
@@ -114,8 +114,8 @@ class TRestDetectorSignal {
     Double_t GetMinTime() const;
     Double_t GetMaxTime() const;
 
-    Double_t GetData(Int_t index) const { return (double)fSignalCharge[index]; }
-    Double_t GetTime(Int_t index) const { return (double)fSignalTime[index]; }
+    Double_t GetData(Int_t index) const { return fSignalCharge[index]; }
+    Double_t GetTime(Int_t index) const { return fSignalTime[index]; }
 
     // Setters
     void SetSignalID(Int_t sID) { fSignalID = sID; }

--- a/inc/TRestDetectorSignal.h
+++ b/inc/TRestDetectorSignal.h
@@ -52,7 +52,7 @@ class TRestDetectorSignal {
     void IncreaseAmplitude(const TVector2& p);
     void SetPoint(const TVector2& p);
 
-    // TODO other objects should probably skip using GetMaxIndex direclty
+    // TODO other objects should probably skip using GetMaxIndex directly
     Int_t GetMaxIndex(Int_t from = 0, Int_t to = 0);
 
     TVector2 GetMaxGauss();
@@ -97,7 +97,7 @@ class TRestDetectorSignal {
 
     void Normalize(Double_t scale = 1.);
 
-    std::vector<Int_t> GetPointsOverThreshold() { return fPointsOverThreshold; }
+    std::vector<Int_t> GetPointsOverThreshold() const { return fPointsOverThreshold; }
 
     Double_t GetAverage(Int_t start = 0, Int_t end = 0);
     Int_t GetMaxPeakWidth();

--- a/src/TRestDetectorHitsToSignalProcess.cxx
+++ b/src/TRestDetectorHitsToSignalProcess.cxx
@@ -320,12 +320,6 @@ TRestEvent* TRestDetectorHitsToSignalProcess::ProcessEvent(TRestEvent* inputEven
 
     fSignalEvent->SortSignals();
 
-    const auto minTime = fSignalEvent->GetMinTime();
-    if (minTime < 0) {
-        RESTError << "TRestDetectorHitsToSignalProcess: Negative time. This should not happen." << RESTendl;
-        exit(1);
-    }
-
     if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "TRestDetectorHitsToSignalProcess : Number of signals added : "
              << fSignalEvent->GetNumberOfSignals() << endl;

--- a/src/TRestDetectorHitsToSignalProcess.cxx
+++ b/src/TRestDetectorHitsToSignalProcess.cxx
@@ -267,6 +267,13 @@ TRestEvent* TRestDetectorHitsToSignalProcess::ProcessEvent(TRestEvent* inputEven
                     velocity = REST_Physics::lightSpeed;
                 }
 
+                if (velocity <= 0) {
+                    RESTError
+                        << "TRestDetectorHitsToSignalProcess: Negative velocity. This should not happen."
+                        << RESTendl;
+                    exit(1);
+                }
+
                 Double_t time = t + distance / velocity;
 
                 if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug && hit < 20) {
@@ -290,6 +297,12 @@ TRestEvent* TRestDetectorHitsToSignalProcess::ProcessEvent(TRestEvent* inputEven
 
                 time = floor(time / fSampling) * fSampling;
 
+                if (time < 0) {
+                    RESTError << "TRestDetectorHitsToSignalProcess: Negative time. This should not happen. "
+                                 "EventID: "
+                              << fHitsEvent->GetID() << RESTendl;
+                    exit(1);
+                }
                 fSignalEvent->AddChargeToSignal(daqId, time, energy);
 
                 auto signal = fSignalEvent->GetSignalById(daqId);

--- a/src/TRestDetectorHitsToSignalProcess.cxx
+++ b/src/TRestDetectorHitsToSignalProcess.cxx
@@ -320,6 +320,12 @@ TRestEvent* TRestDetectorHitsToSignalProcess::ProcessEvent(TRestEvent* inputEven
 
     fSignalEvent->SortSignals();
 
+    const auto minTime = fSignalEvent->GetMinTime();
+    if (minTime < 0) {
+        RESTError << "TRestDetectorHitsToSignalProcess: Negative time. This should not happen." << RESTendl;
+        exit(1);
+    }
+
     if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "TRestDetectorHitsToSignalProcess : Number of signals added : "
              << fSignalEvent->GetNumberOfSignals() << endl;

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -80,14 +80,15 @@ void TRestDetectorSignal::IncreaseAmplitude(const TVector2& p) {
         fSignalCharge[index] += y;
         if (GetTime(index) < 0) {
             RESTWarning << "TRestDetectorSignal::IncreaseAmplitude :: Negative time value in signal "
-                        << fSignalID << " at time " << GetTime(index) << RESTendl;
+                        << fSignalID << " at time " << GetTime(index) << " x: " << x << RESTendl;
         }
     } else {
         fSignalTime.push_back(x);
         fSignalCharge.push_back(y);
-        if (GetTime(GetNumberOfPoints()) < 0) {
-            RESTWarning << "TRestDetectorSignal::IncreaseAmplitude :: Negative time value in signal "
-                        << fSignalID << " at time " << GetTime(index) << RESTendl;
+        if (GetTime(GetNumberOfPoints() - 1) < 0) {
+            RESTWarning << "TRestDetectorSignal::IncreaseAmplitude :: (push) Negative time value in signal "
+                        << fSignalID << " at time " << GetTime(GetNumberOfPoints() - 1) << " x: " << x
+                        << RESTendl;
         }
     }
 }

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -72,31 +72,19 @@ void TRestDetectorSignal::IncreaseAmplitude(const TVector2& p) {
     Double_t y = p.Y();
     Int_t index = GetTimeIndex(x);
 
-    if (x < 0) {
-        RESTWarning << "Negative time value in signal " << fSignalID << " at time " << x << RESTendl;
-    }
     if (index >= 0) {
         fSignalTime[index] = x;
         fSignalCharge[index] += y;
-        if (GetTime(index) < 0) {
-            RESTWarning << "TRestDetectorSignal::IncreaseAmplitude :: Negative time value in signal "
-                        << fSignalID << " at time " << GetTime(index) << " x: " << x << RESTendl;
-        }
     } else {
         fSignalTime.push_back(x);
         fSignalCharge.push_back(y);
-        if (GetTime(GetNumberOfPoints() - 1) < 0) {
-            RESTWarning << "TRestDetectorSignal::IncreaseAmplitude :: (push) Negative time value in signal "
-                        << fSignalID << " at time " << GetTime(GetNumberOfPoints() - 1) << " x: " << x
-                        << RESTendl;
-        }
     }
 }
 
 ///////////////////////////////////////////////
 /// \brief If the point already exists inside the detector signal event,
 /// it will be overwritten. If it does not exists, a new point will be
-/// added to the poins vector.
+/// added to the points vector.
 ///
 /// The input vector should contain a physical time and an amplitude.
 ///
@@ -492,37 +480,29 @@ Int_t TRestDetectorSignal::GetMinIndex() const {
 }
 
 Double_t TRestDetectorSignal::GetMinTime() const {
+    if (GetNumberOfPoints() == 0) {
+        return 0;
+    }
     Double_t minTime = numeric_limits<Double_t>::max();
-    bool found = false;
     for (int i = 0; i < GetNumberOfPoints(); i++) {
         const Double_t time = GetTime(i);
-        if (time < 0) {
-            RESTWarning << "TRestDetectorSignal::GetMinTime - Negative time value in signal " << fSignalID
-                        << " at time " << time << " at index " << i << RESTendl;
-        }
         if (time < minTime) {
             minTime = time;
-            found = true;
         }
-    }
-    if (!found) {
-        minTime = 0;
     }
     return minTime;
 }
 
 Double_t TRestDetectorSignal::GetMaxTime() const {
+    if (GetNumberOfPoints() == 0) {
+        return 0;
+    }
     Double_t maxTime = numeric_limits<Double_t>::min();
-    bool found = false;
     for (int i = 0; i < GetNumberOfPoints(); i++) {
         const auto time = GetTime(i);
         if (time > maxTime) {
             maxTime = time;
-            found = true;
         }
-    }
-    if (!found) {
-        maxTime = 0;
     }
     return maxTime;
 }

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -486,13 +486,15 @@ Int_t TRestDetectorSignal::GetMinIndex() const {
 
 Double_t TRestDetectorSignal::GetMinTime() const {
     Double_t minTime = numeric_limits<Double_t>::max();
+    bool found = false;
     for (int i = 0; i < GetNumberOfPoints(); i++) {
         const auto time = GetTime(i);
         if (time < minTime) {
             minTime = time;
+            found = true;
         }
     }
-    if (minTime == numeric_limits<Double_t>::max()) {
+    if (!found) {
         minTime = 0;
     }
     return minTime;
@@ -500,13 +502,15 @@ Double_t TRestDetectorSignal::GetMinTime() const {
 
 Double_t TRestDetectorSignal::GetMaxTime() const {
     Double_t maxTime = numeric_limits<Double_t>::min();
+    bool found = false;
     for (int i = 0; i < GetNumberOfPoints(); i++) {
         const auto time = GetTime(i);
         if (time > maxTime) {
             maxTime = time;
+            found = true;
         }
     }
-    if (maxTime == numeric_limits<Double_t>::min()) {
+    if (!found) {
         maxTime = 0;
     }
     return maxTime;

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -78,9 +78,17 @@ void TRestDetectorSignal::IncreaseAmplitude(const TVector2& p) {
     if (index >= 0) {
         fSignalTime[index] = x;
         fSignalCharge[index] += y;
+        if (GetTime(index) < 0) {
+            RESTWarning << "TRestDetectorSignal::IncreaseAmplitude :: Negative time value in signal "
+                        << fSignalID << " at time " << GetTime(index) << RESTendl;
+        }
     } else {
         fSignalTime.push_back(x);
         fSignalCharge.push_back(y);
+        if (GetTime(GetNumberOfPoints()) < 0) {
+            RESTWarning << "TRestDetectorSignal::IncreaseAmplitude :: Negative time value in signal "
+                        << fSignalID << " at time " << GetTime(index) << RESTendl;
+        }
     }
 }
 

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -471,7 +471,7 @@ Double_t TRestDetectorSignal::GetMaxPeakTime(Int_t from, Int_t to) { return GetT
 Double_t TRestDetectorSignal::GetMinPeakValue() { return GetData(GetMinIndex()); }
 
 Int_t TRestDetectorSignal::GetMinIndex() const {
-    Double_t min = numeric_limits<double>::max();
+    Double_t min = numeric_limits<Double_t>::max();
     Int_t index = 0;
 
     for (int i = 0; i < GetNumberOfPoints(); i++) {
@@ -485,28 +485,28 @@ Int_t TRestDetectorSignal::GetMinIndex() const {
 }
 
 Double_t TRestDetectorSignal::GetMinTime() const {
-    Double_t minTime = numeric_limits<float>::max();
+    Double_t minTime = numeric_limits<Double_t>::max();
     for (int i = 0; i < GetNumberOfPoints(); i++) {
         const auto time = GetTime(i);
         if (time < minTime) {
             minTime = time;
         }
     }
-    if (minTime == numeric_limits<float>::max()) {
+    if (minTime == numeric_limits<Double_t>::max()) {
         minTime = 0;
     }
     return minTime;
 }
 
 Double_t TRestDetectorSignal::GetMaxTime() const {
-    Double_t maxTime = numeric_limits<float>::min();
+    Double_t maxTime = numeric_limits<Double_t>::min();
     for (int i = 0; i < GetNumberOfPoints(); i++) {
         const auto time = GetTime(i);
         if (time > maxTime) {
             maxTime = time;
         }
     }
-    if (maxTime == numeric_limits<float>::min()) {
+    if (maxTime == numeric_limits<Double_t>::min()) {
         maxTime = 0;
     }
     return maxTime;

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -486,7 +486,11 @@ Double_t TRestDetectorSignal::GetMinTime() const {
     Double_t minTime = numeric_limits<Double_t>::max();
     bool found = false;
     for (int i = 0; i < GetNumberOfPoints(); i++) {
-        const auto time = GetTime(i);
+        const Double_t time = GetTime(i);
+        if (time < 0) {
+            RESTWarning << "TRestDetectorSignal::GetMinTime - Negative time value in signal " << fSignalID
+                        << " at time " << time << " at index " << i << RESTendl;
+        }
         if (time < minTime) {
             minTime = time;
             found = true;

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -68,10 +68,13 @@ void TRestDetectorSignal::IncreaseAmplitude(Double_t t, Double_t d) { IncreaseAm
 /// The input vector should contain a physical time and an amplitude.
 ///
 void TRestDetectorSignal::IncreaseAmplitude(const TVector2& p) {
-    Int_t index = GetTimeIndex(p.X());
     Double_t x = p.X();
     Double_t y = p.Y();
+    Int_t index = GetTimeIndex(x);
 
+    if (x < 0) {
+        RESTWarning << "Negative time value in signal " << fSignalID << " at time " << x << RESTendl;
+    }
     if (index >= 0) {
         fSignalTime[index] = x;
         fSignalCharge[index] += y;

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -50,7 +50,7 @@ TRestDetectorSignal::TRestDetectorSignal() {
 
 TRestDetectorSignal::~TRestDetectorSignal() = default;
 
-void TRestDetectorSignal::NewPoint(Float_t time, Float_t data) {
+void TRestDetectorSignal::NewPoint(Double_t time, Double_t data) {
     fSignalTime.push_back(time);
     fSignalCharge.push_back(data);
 }
@@ -69,8 +69,8 @@ void TRestDetectorSignal::IncreaseAmplitude(Double_t t, Double_t d) { IncreaseAm
 ///
 void TRestDetectorSignal::IncreaseAmplitude(const TVector2& p) {
     Int_t index = GetTimeIndex(p.X());
-    Float_t x = p.X();
-    Float_t y = p.Y();
+    Double_t x = p.X();
+    Double_t y = p.Y();
 
     if (index >= 0) {
         fSignalTime[index] = x;
@@ -90,8 +90,8 @@ void TRestDetectorSignal::IncreaseAmplitude(const TVector2& p) {
 ///
 void TRestDetectorSignal::SetPoint(const TVector2& p) {
     Int_t index = GetTimeIndex(p.X());
-    Float_t x = p.X();
-    Float_t y = p.Y();
+    Double_t x = p.X();
+    Double_t y = p.Y();
 
     if (index >= 0) {
         fSignalTime[index] = x;
@@ -512,7 +512,7 @@ Double_t TRestDetectorSignal::GetMaxTime() const {
 }
 
 Int_t TRestDetectorSignal::GetTimeIndex(Double_t t) {
-    Float_t time = t;
+    Double_t time = t;
 
     for (int n = 0; n < GetNumberOfPoints(); n++) {
         if (time == fSignalTime[n]) {
@@ -634,9 +634,10 @@ void TRestDetectorSignal::MultiplySignalBy(Double_t factor) {
 
 void TRestDetectorSignal::ExponentialConvolution(Double_t fromTime, Double_t decayTime, Double_t offset) {
     for (int i = 0; i < GetNumberOfPoints(); i++) {
-        if (fSignalTime[i] > fromTime)
+        if (fSignalTime[i] > fromTime) {
             fSignalCharge[i] =
                 (fSignalCharge[i] - offset) * exp(-(fSignalTime[i] - fromTime) / decayTime) + offset;
+        }
     }
 }
 

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -48,9 +48,7 @@ TRestDetectorSignal::TRestDetectorSignal() {
     fPointsOverThreshold.clear();
 }
 
-TRestDetectorSignal::~TRestDetectorSignal() {
-    // TRestDetectorSignal destructor
-}
+TRestDetectorSignal::~TRestDetectorSignal() = default;
 
 void TRestDetectorSignal::NewPoint(Float_t time, Float_t data) {
     fSignalTime.push_back(time);
@@ -61,10 +59,7 @@ void TRestDetectorSignal::NewPoint(Float_t time, Float_t data) {
 /// \brief If the point already exists inside the detector signal event,
 /// the amplitude value will be added to the corresponding time.
 ///
-void TRestDetectorSignal::IncreaseAmplitude(Double_t t, Double_t d) {
-    TVector2 p(t, d);
-    IncreaseAmplitude(p);
-}
+void TRestDetectorSignal::IncreaseAmplitude(Double_t t, Double_t d) { IncreaseAmplitude({t, d}); }
 
 ///////////////////////////////////////////////
 /// \brief If the point already exists inside the detector signal event,

--- a/src/TRestDetectorSignalEvent.cxx
+++ b/src/TRestDetectorSignalEvent.cxx
@@ -138,10 +138,11 @@ Double_t TRestDetectorSignalEvent::GetMinValue() {
 
 Double_t TRestDetectorSignalEvent::GetMinTime() {
     Double_t minTime = numeric_limits<Double_t>::max();
-    for (int s = 0; s < GetNumberOfSignals(); s++)
+    for (int s = 0; s < GetNumberOfSignals(); s++) {
         if (minTime > fSignal[s].GetMinTime()) {
             minTime = fSignal[s].GetMinTime();
         }
+    }
     return minTime;
 }
 


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 45](https://badgen.net/badge/PR%20Size/Ok%3A%2045/green) [![](https://github.com/rest-for-physics/detectorlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=missing-observables)](https://github.com/rest-for-physics/detectorlib/commits/missing-observables) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Use double instead of float, since sometimes this can cause problem for very large times (coming from geant4).