### PR TITLE
Correctly initialize gas pressure

### DIFF
--- a/inc/TRestDetectorGarfieldDriftProcess.h
+++ b/inc/TRestDetectorGarfieldDriftProcess.h
@@ -64,11 +64,11 @@ class TRestDetectorGarfieldDriftProcess : public TRestEventProcess {
 #endif
    protected:
 #if defined USE_Garfield
-    Double_t fGasPressure;     // atm
-                               //         Double_t fElectricField; // V/cm
-    Double_t fDriftPotential;  // V
-    Double_t fPEReduction;     // reduction factor of primary electrons to track
-    double fStopDistance;      ///< Distance from readout to stop electron drift, in mm
+    Double_t fGasPressure = -1;  // atm
+                                 //         Double_t fElectricField; // V/cm
+    Double_t fDriftPotential;    // V
+    Double_t fPEReduction;       // reduction factor of primary electrons to track
+    double fStopDistance;        ///< Distance from readout to stop electron drift, in mm
 
     TString fGDML_Filename;
 

--- a/inc/TRestDetectorHitsToSignalProcess.h
+++ b/inc/TRestDetectorHitsToSignalProcess.h
@@ -55,7 +55,7 @@ class TRestDetectorHitsToSignalProcess : public TRestEventProcess {
     Double_t fSampling = 1;  //<
 
     /// The gas pressure. If defined it will change the TRestDetectorGas pressure in atm.
-    Double_t fGasPressure = 1;  // atm
+    Double_t fGasPressure = -1;  // atm
 
     /// The electric field in V/mm. Used to calculate the drift velocity if TRestDetectorGas is defined.
     Double_t fElectricField = 100;  //<

--- a/inc/TRestDetectorHitsToSignalProcess.h
+++ b/inc/TRestDetectorHitsToSignalProcess.h
@@ -58,7 +58,7 @@ class TRestDetectorHitsToSignalProcess : public TRestEventProcess {
     Double_t fGasPressure = -1;  // atm
 
     /// The electric field in V/mm. Used to calculate the drift velocity if TRestDetectorGas is defined.
-    Double_t fElectricField = 100;  //<
+    Double_t fElectricField = -1;  //<
 
     /// The drift velocity in mm/us. If it is negative, it will be calculated from TRestDetectorGas.
     Double_t fDriftVelocity = -1;  // mm/us

--- a/inc/TRestDetectorSignalToHitsProcess.h
+++ b/inc/TRestDetectorSignalToHitsProcess.h
@@ -39,7 +39,7 @@ class TRestDetectorSignalToHitsProcess : public TRestEventProcess {
     /// A pointer to the specific TRestDetectorHitsEvent input
     TRestDetectorSignalEvent* fSignalEvent;  //!
 
-    /// A pointer to the detector readout definition accesible to TRestRun
+    /// A pointer to the detector readout definition accessible to TRestRun
     TRestDetectorReadout* fReadout;  //!
 
     /// A pointer to the detector gas definition accessible to TRestRun
@@ -54,7 +54,7 @@ class TRestDetectorSignalToHitsProcess : public TRestEventProcess {
     Double_t fElectricField = 100;
 
     /// The gas pressure in atm. Only relevant if TRestDetectorGas is used.
-    Double_t fGasPressure = 1;
+    Double_t fGasPressure = -1;
 
     /// The drift velocity in standard REST units (mm/us).
     Double_t fDriftVelocity = -1;
@@ -98,7 +98,7 @@ class TRestDetectorSignalToHitsProcess : public TRestEventProcess {
 
     TRestDetectorSignalToHitsProcess();
     TRestDetectorSignalToHitsProcess(const char* configFilename);
-    ~TRestDetectorSignalToHitsProcess();
+    ~TRestDetectorSignalToHitsProcess() override;
 
     ClassDefOverride(TRestDetectorSignalToHitsProcess, 4);
 };

--- a/inc/TRestDetectorSignalToHitsProcess.h
+++ b/inc/TRestDetectorSignalToHitsProcess.h
@@ -51,7 +51,7 @@ class TRestDetectorSignalToHitsProcess : public TRestEventProcess {
 
    protected:
     /// The electric field in standard REST units (V/mm). Only relevant if TRestDetectorGas is used.
-    Double_t fElectricField = 100;
+    Double_t fElectricField = -1;
 
     /// The gas pressure in atm. Only relevant if TRestDetectorGas is used.
     Double_t fGasPressure = -1;

--- a/src/TRestDetectorElectronDiffusionProcess.cxx
+++ b/src/TRestDetectorElectronDiffusionProcess.cxx
@@ -35,7 +35,7 @@ void TRestDetectorElectronDiffusionProcess::LoadDefaultConfig() {
 
     fElectricField = 2000;
     fAttachment = 0;
-    fGasPressure = 1;
+    fGasPressure = -1;
 }
 
 void TRestDetectorElectronDiffusionProcess::Initialize() {
@@ -44,7 +44,7 @@ void TRestDetectorElectronDiffusionProcess::Initialize() {
 
     fElectricField = 0;
     fAttachment = 0;
-    fGasPressure = 1;
+    fGasPressure = -1;
 
     fTransversalDiffusionCoefficient = 0;
     fLongitudinalDiffusionCoefficient = 0;

--- a/src/TRestDetectorGarfieldDriftProcess.cxx
+++ b/src/TRestDetectorGarfieldDriftProcess.cxx
@@ -416,7 +416,9 @@ TRestEvent* TRestDetectorGarfieldDriftProcess::ProcessEvent(TRestEvent* inputEve
         }
     }
 
-    if (fOutputHitsEvent->GetNumberOfHits() == 0) return nullptr;
+    if (fOutputHitsEvent->GetNumberOfHits() == 0) {
+        return nullptr;
+    }
 
     // fSignalEvent->PrintEvent();
 

--- a/src/TRestDetectorHitsToSignalProcess.cxx
+++ b/src/TRestDetectorHitsToSignalProcess.cxx
@@ -148,8 +148,8 @@ void TRestDetectorHitsToSignalProcess::LoadDefaultConfig() {
     cout << "Hits to signal metadata not found. Loading default values" << endl;
 
     fSampling = 1;
-    fElectricField = 1000;
-    fGasPressure = 10;
+    fElectricField = -1;
+    fGasPressure = -1;
 }
 
 ///////////////////////////////////////////////


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 84](https://badgen.net/badge/PR%20Size/Ok%3A%2084/green) [![](https://github.com/rest-for-physics/detectorlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=lobis-gas-pressure)](https://github.com/rest-for-physics/detectorlib/commits/lobis-gas-pressure) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Because gas pressure is defined to be 1.0 by default, the condition where it checks if it's undefined then load it from the gas metadata is never triggered. This change will make it that if undefined, it will attempt to load it from the gas metadata.