### PR TITLE
Add option to ignore z in `TRestDetectorHitsReadoutAnalysisProcess`

### DIFF
--- a/inc/TRestDetectorHitsReadoutAnalysisProcess.h
+++ b/inc/TRestDetectorHitsReadoutAnalysisProcess.h
@@ -7,11 +7,12 @@
 
 #include <TCanvas.h>
 #include <TH1D.h>
-#include <TRestDetectorGas.h>
-#include <TRestDetectorHitsEvent.h>
-#include <TRestDetectorReadout.h>
-#include <TRestDetectorSignalEvent.h>
 #include <TRestEventProcess.h>
+
+#include "TRestDetectorGas.h"
+#include "TRestDetectorHitsEvent.h"
+#include "TRestDetectorReadout.h"
+#include "TRestDetectorSignalEvent.h"
 
 //! An analysis REST process to extract valuable information from Hits type of data.
 class TRestDetectorHitsReadoutAnalysisProcess : public TRestEventProcess {
@@ -28,6 +29,9 @@ class TRestDetectorHitsReadoutAnalysisProcess : public TRestEventProcess {
     TVector3 fFiducialPosition;
     Double_t fFiducialDiameter = 0;
     bool fRemoveZeroEnergyEvents = false;
+    /// \brief If true, the Z coordinate will be ignored when checking if a position is inside the readout.
+    /// This is required if processing experimental data where only relative z is available.
+    bool fIgnoreZ = false;
 
     TRestDetectorReadout* fReadout = nullptr;  //!
 
@@ -48,7 +52,7 @@ class TRestDetectorHitsReadoutAnalysisProcess : public TRestEventProcess {
 
     ~TRestDetectorHitsReadoutAnalysisProcess() override = default;
 
-    ClassDefOverride(TRestDetectorHitsReadoutAnalysisProcess, 2);
+    ClassDefOverride(TRestDetectorHitsReadoutAnalysisProcess, 3);
 };
 
 #endif  // REST_TRESTDETECTORHITSREADOUTANALYSISPROCESS_H

--- a/src/TRestDetectorHitsReadoutAnalysisProcess.cxx
+++ b/src/TRestDetectorHitsReadoutAnalysisProcess.cxx
@@ -29,8 +29,11 @@ TRestEvent* TRestDetectorHitsReadoutAnalysisProcess::ProcessEvent(TRestEvent* in
                  << "Negative energy found in hit " << hitIndex << endl;
             exit(1);
         }
-
-        const auto daqId = fReadout->GetDaqId(position, false);
+        // when working with hits derived from experimental data, only relative z is available, so it cannot
+        // be used to check if a position is inside the readout. We use z=0 in this case which in most cases
+        // is inside.
+        const auto daqId =
+            fReadout->GetDaqId({position.X(), position.Y(), fIgnoreZ ? 0 : position.Z()}, false);
         const auto channelType = fReadout->GetTypeForChannelDaqId(daqId);
         const bool isValidHit = channelType == fChannelType;
 
@@ -156,6 +159,7 @@ void TRestDetectorHitsReadoutAnalysisProcess::PrintMetadata() {
 
 void TRestDetectorHitsReadoutAnalysisProcess::InitFromConfigFile() {
     fRemoveZeroEnergyEvents = StringToBool(GetParameter("removeZeroEnergyEvents", "false"));
+    fIgnoreZ = StringToBool(GetParameter("ignoreZ", "false"));
     fChannelType = GetParameter("channelType", fChannelType);
     fFiducialPosition = Get3DVectorParameterWithUnits("fiducialPosition", fFiducialPosition);
     fFiducialDiameter = GetDblParameterWithUnits("fiducialDiameter", fFiducialDiameter);


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 15](https://badgen.net/badge/PR%20Size/Ok%3A%2015/green) [![](https://github.com/rest-for-physics/detectorlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=readout-analysis-z)](https://github.com/rest-for-physics/detectorlib/commits/readout-analysis-z) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

@mariajmz  and @JPorron found an error when using this process with experimental data. This is because experimental data has only relative z so it cannot be used to check if a hit is inside readout or not.

This PR introduces a new parameter `ignoreZ` which when set to `true` will ignore z when retrieving channel from position. It is disabled by default so the behaviour remains unchanged unless this option is set.