### PR TITLE
Fixing problems with TRestDetectorSignal fitting methods

### DIFF
--- a/inc/TRestDetectorSignal.h
+++ b/inc/TRestDetectorSignal.h
@@ -138,7 +138,7 @@ class TRestDetectorSignal {
     void ExponentialConvolution(Double_t fromTime, Double_t decayTime, Double_t offset = 0);
     void SignalAddition(TRestDetectorSignal* inSgnl);
 
-    Bool_t isSorted();
+    Bool_t isSorted() const;
     void Sort();
 
     void GetDifferentialSignal(TRestDetectorSignal* diffSgnl, Int_t smearPoints = 5);
@@ -157,7 +157,7 @@ class TRestDetectorSignal {
         fSignalCharge.clear();
     }
 
-    void WriteSignalToTextFile(const TString& filename);
+    void WriteSignalToTextFile(const TString& filename) const;
     void Print() const;
 
     TGraph* GetGraph(Int_t color = 1);

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -313,10 +313,6 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
         }
     }
 
-    std::cout << "The max is " << maxRaw << " " << GetData(maxRaw) << " " << maxRawTime << std::endl;
-    std::cout << "The threshold is " << threshold << std::endl;
-    std::cout << "The range is " << lowerLimit << " " << upperLimit << std::endl;
-
     TF1 gaus("gaus", "gaus", lowerLimit, upperLimit);
     TH1F h1("h1", "h1", GetNumberOfPoints(), GetTime(0), GetTime(GetNumberOfPoints() - 1));
 

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -371,21 +371,21 @@ TRestDetectorSignal::GetMaxLandau()  // returns a 2vector with the time of the p
     Double_t lowerLimit = maxRawTime - 0.2;  // us
     Double_t upperLimit = maxRawTime + 0.4;  // us
 
-    TF1* landau = new TF1("landau", "landau", lowerLimit, upperLimit);
-    TH1F* h1 = new TH1F("h1", "h1", 1000, 0,
-                        10);  // Histogram to store the signal. For now the number of bins is fixed.
+    TF1 landau("landau", "landau", lowerLimit, upperLimit);
+    TH1F h1("h1", "h1", GetNumberOfPoints(), GetTime(0), GetTime(GetNumberOfPoints() - 1));
+
 
     // copying the signal peak to a histogram
     for (int i = 0; i < GetNumberOfPoints(); i++) {
-        h1->Fill(GetTime(i), GetData(i));
+        h1.SetBinContent(i + 1, GetData(i));
     }
 
     TFitResultPtr fitResult =
-        h1->Fit(landau, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in the function range;
+        h1.Fit(&landau, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in the function range;
                                   // S = save and return the fit result
     if (fitResult->IsValid()) {
-        energy = landau->GetParameter(0);
-        time = landau->GetParameter(1);
+        energy = landau.GetParameter(0);
+        time = landau.GetParameter(1);
     } else {
         // the fit failed, return -1 to indicate failure
         energy = -1;
@@ -394,8 +394,8 @@ TRestDetectorSignal::GetMaxLandau()  // returns a 2vector with the time of the p
              << "WARNING: bad fit to signal with ID " << GetID() << " with maximum at time = " << maxRawTime
              << " ns "
              << "\n"
-             << "Failed fit parameters = " << landau->GetParameter(0) << " || " << landau->GetParameter(1)
-             << " || " << landau->GetParameter(2) << "\n"
+             << "Failed fit parameters = " << landau.GetParameter(0) << " || " << landau.GetParameter(1)
+             << " || " << landau.GetParameter(2) << "\n"
              << "Assigned fit parameters : energy = " << energy << ", time = " << time << endl;
         /*
         TCanvas* c2 = new TCanvas("c2", "Signal fit", 200, 10, 1280, 720);
@@ -407,9 +407,6 @@ TRestDetectorSignal::GetMaxLandau()  // returns a 2vector with the time of the p
     }
 
     TVector2 fitParam(time, energy);
-
-    delete h1;
-    delete landau;
 
     return fitParam;
 }

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -322,7 +322,7 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
 
     // copying the signal peak to a histogram
     for (int i = 0; i < GetNumberOfPoints(); i++) {
-        h1.SetBinContent(i+1, GetData(i));
+        h1.SetBinContent(i + 1, GetData(i));
     }
     /*
     TCanvas* c = new TCanvas("c", "Signal fit", 200, 10, 1280, 720);
@@ -346,8 +346,8 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
              << "WARNING: bad fit to signal with ID " << GetID() << " with maximum at time = " << maxRawTime
              << " ns "
              << "\n"
-             << "Failed fit parameters = " << gaus.GetParameter(0) << " || " << gaus.GetParameter(1)
-             << " || " << gaus.GetParameter(2) << "\n"
+             << "Failed fit parameters = " << gaus.GetParameter(0) << " || " << gaus.GetParameter(1) << " || "
+             << gaus.GetParameter(2) << "\n"
              << "Assigned fit parameters : energy = " << energy << ", time = " << time << endl;
         /*
         TCanvas* c2 = new TCanvas("c2", "Signal fit", 200, 10, 1280, 720);

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -293,7 +293,7 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
     Double_t energy = 0, time = 0;
 
     // Define fit limits
-    Double_t threshold = maxRaw * 0.10;  // 10% of the maximum value
+    Double_t threshold = maxRaw * 0.10;      // 10% of the maximum value
     Double_t lowerLimit = maxRawTime - 0.2;  // us
     Double_t upperLimit = maxRawTime + 0.4;  // us
 

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -297,7 +297,7 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
 
     Double_t lowerLimit = maxRawTime, upperLimit = maxRawTime;
 
-    // Find the lower limit: time where signal drops to 90% of the max before the peak
+    // Find the lower limit: time when signal drops to 90% of the max before the peak
     for (int i = maxRaw; i >= 0; --i) {
         if (GetData(i) <= threshold) {
             lowerLimit = GetTime(i);
@@ -305,7 +305,7 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
         }
     }
 
-    // Find the upper limit: time where signal drops to 90% of the max after the peak
+    // Find the upper limit: time when signal drops to 90% of the max after the peak
     for (int i = maxRaw; i < GetNumberOfPoints(); ++i) {
         if (GetData(i) <= threshold) {
             upperLimit = GetTime(i);
@@ -314,22 +314,21 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
     }
 
     TF1 gaus("gaus", "gaus", lowerLimit, upperLimit);
-    TH1F h1("h1", "h1", GetNumberOfPoints(), GetTime(0), GetTime(GetNumberOfPoints() - 1));
+    TH1F h("h", "h", GetNumberOfPoints(), GetTime(0), GetTime(GetNumberOfPoints() - 1));
 
     // copying the signal peak to a histogram
     for (int i = 0; i < GetNumberOfPoints(); i++) {
-        h1.SetBinContent(i + 1, GetData(i));
+        h.SetBinContent(i + 1, GetData(i));
     }
     /*
     TCanvas* c = new TCanvas("c", "Signal fit", 200, 10, 1280, 720);
-    h1->GetXaxis()->SetTitle("Time (us)");
-    h1->GetYaxis()->SetTitle("Amplitude");
-    h1->Draw();
+    h->GetXaxis()->SetTitle("Time (us)");
+    h->GetYaxis()->SetTitle("Amplitude");
+    h->Draw();
     */
 
-    TFitResultPtr fitResult =
-        h1.Fit(&gaus, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in the function range; S
-                                // = save and return the fit result
+    TFitResultPtr fitResult = h.Fit(&gaus, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in
+                                                     // the function range; S = save and return the fit result
 
     if (fitResult->IsValid()) {
         energy = gaus.GetParameter(0);
@@ -340,23 +339,20 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
         time = -1;
         cout << endl
              << "WARNING: bad fit to signal with ID " << GetID() << " with maximum at time = " << maxRawTime
-             << " ns "
-             << "\n"
+             << " ns " << "\n"
              << "Failed fit parameters = " << gaus.GetParameter(0) << " || " << gaus.GetParameter(1) << " || "
              << gaus.GetParameter(2) << "\n"
              << "Assigned fit parameters : energy = " << energy << ", time = " << time << endl;
         /*
         TCanvas* c2 = new TCanvas("c2", "Signal fit", 200, 10, 1280, 720);
-        h1->Draw();
+        h->Draw();
         c2->Update();
         getchar();
         delete c2;
         */
     }
 
-    TVector2 fitParam(time, energy);
-
-    return fitParam;
+    return {time, energy};
 }
 
 // z position by landau fit
@@ -374,7 +370,7 @@ TRestDetectorSignal::GetMaxLandau()  // returns a 2vector with the time of the p
 
     Double_t lowerLimit = maxRawTime, upperLimit = maxRawTime;
 
-    // Find the lower limit: time where signal drops to 90% of the max before the peak
+    // Find the lower limit: time when signal drops to 90% of the max before the peak
     for (int i = maxRaw; i >= 0; --i) {
         if (GetData(i) <= threshold) {
             lowerLimit = GetTime(i);
@@ -382,7 +378,7 @@ TRestDetectorSignal::GetMaxLandau()  // returns a 2vector with the time of the p
         }
     }
 
-    // Find the upper limit: time where signal drops to 90% of the max after the peak
+    // Find the upper limit: time when signal drops to 90% of the max after the peak
     for (int i = maxRaw; i < GetNumberOfPoints(); ++i) {
         if (GetData(i) <= threshold) {
             upperLimit = GetTime(i);
@@ -391,16 +387,16 @@ TRestDetectorSignal::GetMaxLandau()  // returns a 2vector with the time of the p
     }
 
     TF1 landau("landau", "landau", lowerLimit, upperLimit);
-    TH1F h1("h1", "h1", GetNumberOfPoints(), GetTime(0), GetTime(GetNumberOfPoints() - 1));
+    TH1F h("h", "h", GetNumberOfPoints(), GetTime(0), GetTime(GetNumberOfPoints() - 1));
 
     // copying the signal peak to a histogram
     for (int i = 0; i < GetNumberOfPoints(); i++) {
-        h1.SetBinContent(i + 1, GetData(i));
+        h.SetBinContent(i + 1, GetData(i));
     }
 
     TFitResultPtr fitResult =
-        h1.Fit(&landau, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in the function range;
-                                  // S = save and return the fit result
+        h.Fit(&landau, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in the function range;
+                                 // S = save and return the fit result
     if (fitResult->IsValid()) {
         energy = landau.GetParameter(0);
         time = landau.GetParameter(1);
@@ -410,23 +406,20 @@ TRestDetectorSignal::GetMaxLandau()  // returns a 2vector with the time of the p
         time = -1;
         cout << endl
              << "WARNING: bad fit to signal with ID " << GetID() << " with maximum at time = " << maxRawTime
-             << " ns "
-             << "\n"
+             << " ns " << "\n"
              << "Failed fit parameters = " << landau.GetParameter(0) << " || " << landau.GetParameter(1)
              << " || " << landau.GetParameter(2) << "\n"
              << "Assigned fit parameters : energy = " << energy << ", time = " << time << endl;
         /*
         TCanvas* c2 = new TCanvas("c2", "Signal fit", 200, 10, 1280, 720);
-        h1->Draw();
+        h->Draw();
         c2->Update();
         getchar();
         delete c2;
         */
     }
 
-    TVector2 fitParam(time, energy);
-
-    return fitParam;
+    return {time, energy};
 }
 
 // z position by aget fit
@@ -456,7 +449,7 @@ TRestDetectorSignal::GetMaxAget()  // returns a 2vector with the time of the pea
 
     Double_t lowerLimit = maxRawTime, upperLimit = maxRawTime;
 
-    // Find the lower limit: time where signal drops to 90% of the max before the peak
+    // Find the lower limit: time when signal drops to 90% of the max before the peak
     for (int i = maxRaw; i >= 0; --i) {
         if (GetData(i) <= threshold) {
             lowerLimit = GetTime(i);
@@ -464,7 +457,7 @@ TRestDetectorSignal::GetMaxAget()  // returns a 2vector with the time of the pea
         }
     }
 
-    // Find the upper limit: time where signal drops to 90% of the max after the peak
+    // Find the upper limit: time when signal drops to 90% of the max after the peak
     for (int i = maxRaw; i < GetNumberOfPoints(); ++i) {
         if (GetData(i) <= threshold) {
             upperLimit = GetTime(i);
@@ -473,17 +466,16 @@ TRestDetectorSignal::GetMaxAget()  // returns a 2vector with the time of the pea
     }
 
     TF1 aget("aget", agetResponseFunction, lowerLimit, upperLimit, 3);  //
-    TH1F h1("h1", "h1", GetNumberOfPoints(), GetTime(0), GetTime(GetNumberOfPoints() - 1));
+    TH1F h("h", "h", GetNumberOfPoints(), GetTime(0), GetTime(GetNumberOfPoints() - 1));
     aget.SetParameters(500, maxRawTime, 1.2);
 
     // copying the signal peak to a histogram
     for (int i = 0; i < GetNumberOfPoints(); i++) {
-        h1.SetBinContent(i + 1, GetData(i));
+        h.SetBinContent(i + 1, GetData(i));
     }
 
-    TFitResultPtr fitResult =
-        h1.Fit(&aget, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in
-                                // the function range; S = save and return the fit result
+    TFitResultPtr fitResult = h.Fit(&aget, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in
+                                                     // the function range; S = save and return the fit result
 
     if (fitResult->IsValid()) {
         energy = aget.GetParameter(0);
@@ -494,17 +486,15 @@ TRestDetectorSignal::GetMaxAget()  // returns a 2vector with the time of the pea
         time = -1;
         cout << endl
              << "WARNING: bad fit to signal with ID " << GetID() << " with maximum at time = " << maxRawTime
-             << " ns "
-             << "\n"
+             << " ns " << "\n"
              << "Failed fit parameters = " << aget.GetParameter(0) << " || " << aget.GetParameter(1) << " || "
              << aget.GetParameter(2) << "\n"
              << "Assigned fit parameters : energy = " << energy << ", time = " << time << endl;
     }
 
-    TVector2 fitParam(time, energy);
-
-    return fitParam;
+    return {time, energy};
 }
+
 Double_t TRestDetectorSignal::GetMaxPeakTime(Int_t from, Int_t to) { return GetTime(GetMaxIndex(from, to)); }
 
 Double_t TRestDetectorSignal::GetMinPeakValue() { return GetData(GetMinIndex()); }
@@ -562,7 +552,7 @@ Int_t TRestDetectorSignal::GetTimeIndex(Double_t t) {
     return -1;
 }
 
-Bool_t TRestDetectorSignal::isSorted() {
+Bool_t TRestDetectorSignal::isSorted() const {
     for (int i = 0; i < GetNumberOfPoints() - 1; i++) {
         if (GetTime(i + 1) < GetTime(i)) {
             return false;
@@ -762,7 +752,7 @@ void TRestDetectorSignal::GetSignalGaussianConvolution(TRestDetectorSignal* conv
     cout << "Final charge of the pulse " << totChargeFinal << endl;
 }
 
-void TRestDetectorSignal::WriteSignalToTextFile(const TString& filename) {
+void TRestDetectorSignal::WriteSignalToTextFile(const TString& filename) const {
     FILE* fff = fopen(filename.Data(), "w");
     for (int i = 0; i < GetNumberOfPoints(); i++) {
         fprintf(fff, "%e\t%e\n", GetTime(i), GetData(i));

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -368,7 +368,7 @@ TRestDetectorSignal::GetMaxLandau()  // returns a 2vector with the time of the p
     Double_t maxRawTime =
         GetTime(maxRaw);  // The time of the bin where the maximum of the raw signal is found
     Double_t energy = 0, time = 0;
-    
+
     // Define fit limits
     Double_t threshold = GetData(maxRaw) * 0.9;  // 90% of the maximum value
 
@@ -450,7 +450,7 @@ TRestDetectorSignal::GetMaxAget()  // returns a 2vector with the time of the pea
     Double_t maxRawTime =
         GetTime(maxRaw);  // The time of the bin where the maximum of the raw signal is found
     Double_t energy = 0, time = 0;
-    
+
     // Define fit limits
     Double_t threshold = GetData(maxRaw) * 0.9;  // 90% of the maximum value
 

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -368,8 +368,27 @@ TRestDetectorSignal::GetMaxLandau()  // returns a 2vector with the time of the p
     Double_t maxRawTime =
         GetTime(maxRaw);  // The time of the bin where the maximum of the raw signal is found
     Double_t energy = 0, time = 0;
-    Double_t lowerLimit = maxRawTime - 0.2;  // us
-    Double_t upperLimit = maxRawTime + 0.4;  // us
+    
+    // Define fit limits
+    Double_t threshold = GetData(maxRaw) * 0.9;  // 90% of the maximum value
+
+    Double_t lowerLimit = maxRawTime, upperLimit = maxRawTime;
+
+    // Find the lower limit: time where signal drops to 90% of the max before the peak
+    for (int i = maxRaw; i >= 0; --i) {
+        if (GetData(i) <= threshold) {
+            lowerLimit = GetTime(i);
+            break;
+        }
+    }
+
+    // Find the upper limit: time where signal drops to 90% of the max after the peak
+    for (int i = maxRaw; i < GetNumberOfPoints(); ++i) {
+        if (GetData(i) <= threshold) {
+            upperLimit = GetTime(i);
+            break;
+        }
+    }
 
     TF1 landau("landau", "landau", lowerLimit, upperLimit);
     TH1F h1("h1", "h1", GetNumberOfPoints(), GetTime(0), GetTime(GetNumberOfPoints() - 1));
@@ -431,9 +450,27 @@ TRestDetectorSignal::GetMaxAget()  // returns a 2vector with the time of the pea
     Double_t maxRawTime =
         GetTime(maxRaw);  // The time of the bin where the maximum of the raw signal is found
     Double_t energy = 0, time = 0;
-    // The intervals below are small because otherwise the function doesn't fit anymore.
-    Double_t lowerLimit = maxRawTime - 0.2;  // us
-    Double_t upperLimit = maxRawTime + 0.7;  // us
+    
+    // Define fit limits
+    Double_t threshold = GetData(maxRaw) * 0.9;  // 90% of the maximum value
+
+    Double_t lowerLimit = maxRawTime, upperLimit = maxRawTime;
+
+    // Find the lower limit: time where signal drops to 90% of the max before the peak
+    for (int i = maxRaw; i >= 0; --i) {
+        if (GetData(i) <= threshold) {
+            lowerLimit = GetTime(i);
+            break;
+        }
+    }
+
+    // Find the upper limit: time where signal drops to 90% of the max after the peak
+    for (int i = maxRaw; i < GetNumberOfPoints(); ++i) {
+        if (GetData(i) <= threshold) {
+            upperLimit = GetTime(i);
+            break;
+        }
+    }
 
     TF1 aget("aget", agetResponseFunction, lowerLimit, upperLimit, 3);  //
     TH1F h1("h1", "h1", GetNumberOfPoints(), GetTime(0), GetTime(GetNumberOfPoints() - 1));

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -317,13 +317,12 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
     std::cout << "The threshold is " << threshold << std::endl;
     std::cout << "The range is " << lowerLimit << " " << upperLimit << std::endl;
 
-    TF1* gaus = new TF1("gaus", "gaus", lowerLimit, upperLimit);
-    TH1F* h1 = new TH1F("h1", "h1", signal->GetNumberOfPoints(), signal->GetTime(0),
-                        signal->GetTime(signal->GetNumberOfPoints() - 1));
+    TF1 gaus("gaus", "gaus", lowerLimit, upperLimit);
+    TH1F h1("h1", "h1", GetNumberOfPoints(), GetTime(0), GetTime(GetNumberOfPoints() - 1));
 
     // copying the signal peak to a histogram
     for (int i = 0; i < GetNumberOfPoints(); i++) {
-        h1->Fill(GetTime(i), GetData(i));
+        h1.SetBinContent(i+1, GetData(i));
     }
     /*
     TCanvas* c = new TCanvas("c", "Signal fit", 200, 10, 1280, 720);
@@ -333,12 +332,12 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
     */
 
     TFitResultPtr fitResult =
-        h1->Fit(gaus, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in the function range; S
+        h1.Fit(&gaus, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in the function range; S
                                 // = save and return the fit result
 
     if (fitResult->IsValid()) {
-        energy = gaus->GetParameter(0);
-        time = gaus->GetParameter(1);
+        energy = gaus.GetParameter(0);
+        time = gaus.GetParameter(1);
     } else {
         // the fit failed, return -1 to indicate failure
         energy = -1;
@@ -347,8 +346,8 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
              << "WARNING: bad fit to signal with ID " << GetID() << " with maximum at time = " << maxRawTime
              << " ns "
              << "\n"
-             << "Failed fit parameters = " << gaus->GetParameter(0) << " || " << gaus->GetParameter(1)
-             << " || " << gaus->GetParameter(2) << "\n"
+             << "Failed fit parameters = " << gaus.GetParameter(0) << " || " << gaus.GetParameter(1)
+             << " || " << gaus.GetParameter(2) << "\n"
              << "Assigned fit parameters : energy = " << energy << ", time = " << time << endl;
         /*
         TCanvas* c2 = new TCanvas("c2", "Signal fit", 200, 10, 1280, 720);
@@ -360,9 +359,6 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
     }
 
     TVector2 fitParam(time, energy);
-
-    delete h1;
-    delete gaus;
 
     return fitParam;
 }

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -293,7 +293,7 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
     Double_t energy = 0, time = 0;
 
     // Define fit limits
-    Double_t threshold = GetData(maxRaw)*0.9;  // 90% of the maximum value
+    Double_t threshold = GetData(maxRaw) * 0.9;  // 90% of the maximum value
 
     Double_t lowerLimit = maxRawTime, upperLimit = maxRawTime;
 
@@ -313,12 +313,13 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
         }
     }
 
-    std::cout << "The max is " << maxRaw  << " " << GetData(maxRaw) << " " << maxRawTime << std::endl;
+    std::cout << "The max is " << maxRaw << " " << GetData(maxRaw) << " " << maxRawTime << std::endl;
     std::cout << "The threshold is " << threshold << std::endl;
     std::cout << "The range is " << lowerLimit << " " << upperLimit << std::endl;
 
     TF1* gaus = new TF1("gaus", "gaus", lowerLimit, upperLimit);
-    TH1F* h1 = new TH1F("h1", "h1", signal->GetNumberOfPoints(),signal->GetTime(0),signal->GetTime(signal->GetNumberOfPoints()-1));
+    TH1F* h1 = new TH1F("h1", "h1", signal->GetNumberOfPoints(), signal->GetTime(0),
+                        signal->GetTime(signal->GetNumberOfPoints() - 1));
 
     // copying the signal peak to a histogram
     for (int i = 0; i < GetNumberOfPoints(); i++) {

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -459,8 +459,8 @@ TRestDetectorSignal::GetMaxAget()  // returns a 2vector with the time of the pea
              << "WARNING: bad fit to signal with ID " << GetID() << " with maximum at time = " << maxRawTime
              << " ns "
              << "\n"
-             << "Failed fit parameters = " << aget.GetParameter(0) << " || " << aget.GetParameter(1)
-             << " || " << aget.GetParameter(2) << "\n"
+             << "Failed fit parameters = " << aget.GetParameter(0) << " || " << aget.GetParameter(1) << " || "
+             << aget.GetParameter(2) << "\n"
              << "Assigned fit parameters : energy = " << energy << ", time = " << time << endl;
     }
 

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -339,7 +339,8 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
         time = -1;
         cout << endl
              << "WARNING: bad fit to signal with ID " << GetID() << " with maximum at time = " << maxRawTime
-             << " ns " << "\n"
+             << " ns "
+             << "\n"
              << "Failed fit parameters = " << gaus.GetParameter(0) << " || " << gaus.GetParameter(1) << " || "
              << gaus.GetParameter(2) << "\n"
              << "Assigned fit parameters : energy = " << energy << ", time = " << time << endl;
@@ -406,7 +407,8 @@ TRestDetectorSignal::GetMaxLandau()  // returns a 2vector with the time of the p
         time = -1;
         cout << endl
              << "WARNING: bad fit to signal with ID " << GetID() << " with maximum at time = " << maxRawTime
-             << " ns " << "\n"
+             << " ns "
+             << "\n"
              << "Failed fit parameters = " << landau.GetParameter(0) << " || " << landau.GetParameter(1)
              << " || " << landau.GetParameter(2) << "\n"
              << "Assigned fit parameters : energy = " << energy << ", time = " << time << endl;
@@ -486,7 +488,8 @@ TRestDetectorSignal::GetMaxAget()  // returns a 2vector with the time of the pea
         time = -1;
         cout << endl
              << "WARNING: bad fit to signal with ID " << GetID() << " with maximum at time = " << maxRawTime
-             << " ns " << "\n"
+             << " ns "
+             << "\n"
              << "Failed fit parameters = " << aget.GetParameter(0) << " || " << aget.GetParameter(1) << " || "
              << aget.GetParameter(2) << "\n"
              << "Assigned fit parameters : energy = " << energy << ", time = " << time << endl;

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -291,6 +291,9 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
     Double_t maxRawTime =
         GetTime(maxRaw);  // The time of the bin where the maximum of the raw signal is found
     Double_t energy = 0, time = 0;
+
+    // Define fit limits
+    Double_t threshold = maxRaw * 0.10;  // 10% of the maximum value
     Double_t lowerLimit = maxRawTime - 0.2;  // us
     Double_t upperLimit = maxRawTime + 0.4;  // us
 


### PR DESCRIPTION
![mariajmz](https://badgen.net/badge/PR%20submitted%20by%3A/mariajmz/blue) ![Medium: 104](https://badgen.net/badge/PR%20Size/Medium%3A%20104/orange) [![](https://github.com/rest-for-physics/detectorlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=mariajmz_fits)](https://github.com/rest-for-physics/detectorlib/commits/mariajmz_fits) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

DON'T MERGE: This is a work in progress

@JPorron and me detected a problem with the fitting methods: the limits for the fits are hardcoded and are only valid for a sampling time of 20 ns.