### PR TITLE
Use `std::optional` for peak fitting (which can fail) and other minor refactorings

### DIFF
--- a/inc/TRestDetectorSignal.h
+++ b/inc/TRestDetectorSignal.h
@@ -66,11 +66,7 @@ class TRestDetectorSignal {
     void SetSignalType(const std::string& type) { fType = type; }
 
     // Getters
-    TVector2 GetPoint(Int_t n) {
-        TVector2 vector2(GetTime(n), GetData(n));
-
-        return vector2;
-    }
+    TVector2 GetPoint(Int_t n) { return {GetTime(n), GetData(n)}; }
 
     inline Int_t GetSignalID() const { return fSignalID; }
     inline Int_t GetID() const { return fSignalID; }

--- a/inc/TRestDetectorSignal.h
+++ b/inc/TRestDetectorSignal.h
@@ -56,9 +56,9 @@ class TRestDetectorSignal {
     // TODO other objects should probably skip using GetMaxIndex directly
     Int_t GetMaxIndex(Int_t from = 0, Int_t to = 0);
 
-    std::optional<std::pair<Double_t, Double_t>> GetMaxGauss();
-    TVector2 GetMaxLandau();
-    TVector2 GetMaxAget();
+    std::optional<std::pair<Double_t, Double_t>> GetPeakGauss();
+    std::optional<std::pair<Double_t, Double_t>> GetPeakLandau();
+    std::optional<std::pair<Double_t, Double_t>> GetPeakAget();
 
     std::string GetSignalName() const { return fName; }
     std::string GetSignalType() const { return fType; }

--- a/inc/TRestDetectorSignal.h
+++ b/inc/TRestDetectorSignal.h
@@ -56,7 +56,7 @@ class TRestDetectorSignal {
     // TODO other objects should probably skip using GetMaxIndex directly
     Int_t GetMaxIndex(Int_t from = 0, Int_t to = 0);
 
-    std::optional<TVector2> GetMaxGauss();
+    std::optional<std::pair<Double_t, Double_t>> GetMaxGauss();
     TVector2 GetMaxLandau();
     TVector2 GetMaxAget();
 

--- a/inc/TRestDetectorSignal.h
+++ b/inc/TRestDetectorSignal.h
@@ -28,6 +28,7 @@
 #include <TVector2.h>
 
 #include <iostream>
+#include <optional>
 
 class TRestDetectorSignal {
    private:
@@ -55,7 +56,7 @@ class TRestDetectorSignal {
     // TODO other objects should probably skip using GetMaxIndex directly
     Int_t GetMaxIndex(Int_t from = 0, Int_t to = 0);
 
-    TVector2 GetMaxGauss();
+    std::optional<TVector2> GetMaxGauss();
     TVector2 GetMaxLandau();
     TVector2 GetMaxAget();
 

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -305,7 +305,7 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
         }
     }
 
-    // Find the upper limit: time where signal drops to 90% of the max after the peak
+    // Find the upper limit: time when signal drops to 90% of the max after the peak
     for (int i = maxRaw; i < GetNumberOfPoints(); ++i) {
         if (GetData(i) <= threshold) {
             upperLimit = GetTime(i);
@@ -358,9 +358,7 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
         */
     }
 
-    TVector2 fitParam(time, energy);
-
-    return fitParam;
+    return {time, energy};
 }
 
 // z position by landau fit
@@ -410,12 +408,10 @@ TRestDetectorSignal::GetMaxLandau()  // returns a 2vector with the time of the p
         */
     }
 
-    TVector2 fitParam(time, energy);
-
     delete h1;
     delete landau;
 
-    return fitParam;
+    return {time, energy};
 }
 
 // z position by aget fit
@@ -473,12 +469,10 @@ TRestDetectorSignal::GetMaxAget()  // returns a 2vector with the time of the pea
              << "Assigned fit parameters : energy = " << energy << ", time = " << time << endl;
     }
 
-    TVector2 fitParam(time, energy);
-
     delete h1;
     delete aget;
 
-    return fitParam;
+    return {time, energy};
 }
 Double_t TRestDetectorSignal::GetMaxPeakTime(Int_t from, Int_t to) { return GetTime(GetMaxIndex(from, to)); }
 

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -322,7 +322,7 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
 
     // copying the signal peak to a histogram
     for (int i = 0; i < GetNumberOfPoints(); i++) {
-        h1.SetBinContent(i+1, GetData(i));
+        h1.SetBinContent(i + 1, GetData(i));
     }
     /*
     TCanvas* c = new TCanvas("c", "Signal fit", 200, 10, 1280, 720);
@@ -346,8 +346,8 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
              << "WARNING: bad fit to signal with ID " << GetID() << " with maximum at time = " << maxRawTime
              << " ns "
              << "\n"
-             << "Failed fit parameters = " << gaus.GetParameter(0) << " || " << gaus.GetParameter(1)
-             << " || " << gaus.GetParameter(2) << "\n"
+             << "Failed fit parameters = " << gaus.GetParameter(0) << " || " << gaus.GetParameter(1) << " || "
+             << gaus.GetParameter(2) << "\n"
              << "Assigned fit parameters : energy = " << energy << ", time = " << time << endl;
         /*
         TCanvas* c2 = new TCanvas("c2", "Signal fit", 200, 10, 1280, 720);

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -284,20 +284,19 @@ Int_t TRestDetectorSignal::GetMaxIndex(Int_t from, Int_t to) {
 
 // z position by gaussian fit
 
-TVector2
+optional<TVector2>
 TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the peak time in us and the energy
 {
     Int_t maxRaw = GetMaxIndex();  // The bin where the maximum of the raw signal is found
     Double_t maxRawTime =
         GetTime(maxRaw);  // The time of the bin where the maximum of the raw signal is found
-    Double_t energy = 0, time = 0;
 
     // Define fit limits
     Double_t threshold = GetData(maxRaw) * 0.9;  // 90% of the maximum value
 
     Double_t lowerLimit = maxRawTime, upperLimit = maxRawTime;
 
-    // Find the lower limit: time where signal drops to 90% of the max before the peak
+    // Find the lower limit: time when signal drops to 90% of the max before the peak
     for (int i = maxRaw; i >= 0; --i) {
         if (GetData(i) <= threshold) {
             lowerLimit = GetTime(i);
@@ -336,19 +335,17 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
                                 // = save and return the fit result
 
     if (fitResult->IsValid()) {
-        energy = gaus.GetParameter(0);
-        time = gaus.GetParameter(1);
+        double energy = gaus.GetParameter(0);
+        double time = gaus.GetParameter(1);
+
+        return TVector2(time, energy);
     } else {
-        // the fit failed, return -1 to indicate failure
-        energy = -1;
-        time = -1;
+        // The fit failed
         cout << endl
              << "WARNING: bad fit to signal with ID " << GetID() << " with maximum at time = " << maxRawTime
-             << " ns "
-             << "\n"
+             << " ns " << endl
              << "Failed fit parameters = " << gaus.GetParameter(0) << " || " << gaus.GetParameter(1) << " || "
-             << gaus.GetParameter(2) << "\n"
-             << "Assigned fit parameters : energy = " << energy << ", time = " << time << endl;
+             << gaus.GetParameter(2) << endl;
         /*
         TCanvas* c2 = new TCanvas("c2", "Signal fit", 200, 10, 1280, 720);
         h1->Draw();
@@ -356,9 +353,9 @@ TRestDetectorSignal::GetMaxGauss()  // returns a 2vector with the time of the pe
         getchar();
         delete c2;
         */
-    }
 
-    return {time, energy};
+        return nullopt;
+    }
 }
 
 // z position by landau fit
@@ -394,8 +391,7 @@ TRestDetectorSignal::GetMaxLandau()  // returns a 2vector with the time of the p
         time = -1;
         cout << endl
              << "WARNING: bad fit to signal with ID " << GetID() << " with maximum at time = " << maxRawTime
-             << " ns "
-             << "\n"
+             << " ns " << "\n"
              << "Failed fit parameters = " << landau->GetParameter(0) << " || " << landau->GetParameter(1)
              << " || " << landau->GetParameter(2) << "\n"
              << "Assigned fit parameters : energy = " << energy << ", time = " << time << endl;
@@ -462,8 +458,7 @@ TRestDetectorSignal::GetMaxAget()  // returns a 2vector with the time of the pea
         time = -1;
         cout << endl
              << "WARNING: bad fit to signal with ID " << GetID() << " with maximum at time = " << maxRawTime
-             << " ns "
-             << "\n"
+             << " ns " << "\n"
              << "Failed fit parameters = " << aget->GetParameter(0) << " || " << aget->GetParameter(1)
              << " || " << aget->GetParameter(2) << "\n"
              << "Assigned fit parameters : energy = " << energy << ", time = " << time << endl;

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -320,15 +320,11 @@ TRestDetectorSignal::GetPeakGauss()  // returns a 2vector with the time of the p
     }
 
     TF1 gauss("gaus", "gaus", lowerLimit, upperLimit);
-    TH1F h("h", "h", GetNumberOfPoints(), GetTime(0), GetTime(GetNumberOfPoints() - 1));
 
-    // copying the signal peak to a histogram
-    for (int i = 0; i < GetNumberOfPoints(); i++) {
-        h.SetBinContent(i + 1, GetData(i));
-    }
+    auto signal_graph = std::unique_ptr<TGraph>(GetGraph());
 
     TFitResultPtr fitResult =
-        h.Fit(&gauss, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in
+        signal_graph->Fit(&gauss, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in
                                 // the function range; S = save and return the fit result
 
     if (!fitResult->IsValid()) {
@@ -337,7 +333,7 @@ TRestDetectorSignal::GetPeakGauss()  // returns a 2vector with the time of the p
 
     double energy = gauss.GetParameter(0);
     double time = gauss.GetParameter(1);
-
+    
     return make_pair(time, energy);
 }
 
@@ -372,15 +368,11 @@ TRestDetectorSignal::GetPeakLandau()  // returns a 2vector with the time of the 
     }
 
     TF1 landau("landau", "landau", lowerLimit, upperLimit);
-    TH1F h("h", "h", GetNumberOfPoints(), GetTime(0), GetTime(GetNumberOfPoints() - 1));
 
-    // copying the signal peak to a histogram
-    for (int i = 0; i < GetNumberOfPoints(); i++) {
-        h.SetBinContent(i + 1, GetData(i));
-    }
-
+    auto signal_graph = std::unique_ptr<TGraph>(GetGraph());
+    
     TFitResultPtr fitResult =
-        h.Fit(&landau, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in the function range;
+        signal_graph->Fit(&landau, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in the function range;
                                  // S = save and return the fit result
     if (!fitResult->IsValid()) {
         return nullopt;
@@ -435,15 +427,11 @@ TRestDetectorSignal::GetPeakAget()  // returns a 2vector with the time of the pe
     }
 
     TF1 aget("aget", agetResponseFunction, lowerLimit, upperLimit, 3);  //
-    TH1F h("h", "h", GetNumberOfPoints(), GetTime(0), GetTime(GetNumberOfPoints() - 1));
     aget.SetParameters(500, maxRawTime, 1.2);
 
-    // copying the signal peak to a histogram
-    for (int i = 0; i < GetNumberOfPoints(); i++) {
-        h.SetBinContent(i + 1, GetData(i));
-    }
+    auto signal_graph = std::unique_ptr<TGraph>(GetGraph());
 
-    TFitResultPtr fitResult = h.Fit(&aget, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in
+    TFitResultPtr fitResult = signal_graph->Fit(&aget, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in
                                                      // the function range; S = save and return the fit result
 
     if (!fitResult->IsValid()) {

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -376,7 +376,6 @@ TRestDetectorSignal::GetPeakLandau()  // returns a 2vector with the time of the 
 
     // copying the signal peak to a histogram
     for (int i = 0; i < GetNumberOfPoints(); i++) {
-        h.Fill(GetTime(i), GetData(i));
         h.SetBinContent(i + 1, GetData(i));
     }
 
@@ -441,7 +440,6 @@ TRestDetectorSignal::GetPeakAget()  // returns a 2vector with the time of the pe
 
     // copying the signal peak to a histogram
     for (int i = 0; i < GetNumberOfPoints(); i++) {
-        h.Fill(GetTime(i), GetData(i));
         h.SetBinContent(i + 1, GetData(i));
     }
 

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -325,7 +325,7 @@ TRestDetectorSignal::GetPeakGauss()  // returns a 2vector with the time of the p
 
     TFitResultPtr fitResult =
         signal_graph->Fit(&gauss, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in
-                                // the function range; S = save and return the fit result
+                                            // the function range; S = save and return the fit result
 
     if (!fitResult->IsValid()) {
         return nullopt;
@@ -333,7 +333,7 @@ TRestDetectorSignal::GetPeakGauss()  // returns a 2vector with the time of the p
 
     double energy = gauss.GetParameter(0);
     double time = gauss.GetParameter(1);
-    
+
     return make_pair(time, energy);
 }
 
@@ -370,10 +370,10 @@ TRestDetectorSignal::GetPeakLandau()  // returns a 2vector with the time of the 
     TF1 landau("landau", "landau", lowerLimit, upperLimit);
 
     auto signal_graph = std::unique_ptr<TGraph>(GetGraph());
-    
+
     TFitResultPtr fitResult =
-        signal_graph->Fit(&landau, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in the function range;
-                                 // S = save and return the fit result
+        signal_graph->Fit(&landau, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in the
+                                             // function range; S = save and return the fit result
     if (!fitResult->IsValid()) {
         return nullopt;
     }
@@ -431,8 +431,9 @@ TRestDetectorSignal::GetPeakAget()  // returns a 2vector with the time of the pe
 
     auto signal_graph = std::unique_ptr<TGraph>(GetGraph());
 
-    TFitResultPtr fitResult = signal_graph->Fit(&aget, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in
-                                                     // the function range; S = save and return the fit result
+    TFitResultPtr fitResult =
+        signal_graph->Fit(&aget, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in
+                                           // the function range; S = save and return the fit result
 
     if (!fitResult->IsValid()) {
         return nullopt;

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -327,8 +327,9 @@ TRestDetectorSignal::GetPeakGauss()  // returns a 2vector with the time of the p
         h.SetBinContent(i + 1, GetData(i));
     }
 
-    TFitResultPtr fitResult = h.Fit(&gauss, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in
-                                                     // the function range; S = save and return the fit result
+    TFitResultPtr fitResult =
+        h.Fit(&gauss, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in
+                                // the function range; S = save and return the fit result
 
     if (!fitResult->IsValid()) {
         return nullopt;

--- a/src/TRestDetectorSignal.cxx
+++ b/src/TRestDetectorSignal.cxx
@@ -319,45 +319,25 @@ TRestDetectorSignal::GetPeakGauss()  // returns a 2vector with the time of the p
         }
     }
 
-    TF1 gaus("gaus", "gaus", lowerLimit, upperLimit);
+    TF1 gauss("gaus", "gaus", lowerLimit, upperLimit);
     TH1F h("h", "h", GetNumberOfPoints(), GetTime(0), GetTime(GetNumberOfPoints() - 1));
 
     // copying the signal peak to a histogram
     for (int i = 0; i < GetNumberOfPoints(); i++) {
         h.SetBinContent(i + 1, GetData(i));
     }
-    /*
-    TCanvas* c = new TCanvas("c", "Signal fit", 200, 10, 1280, 720);
-    h->GetXaxis()->SetTitle("Time (us)");
-    h->GetYaxis()->SetTitle("Amplitude");
-    h->Draw();
-    */
 
-    TFitResultPtr fitResult = h.Fit(&gaus, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in
+    TFitResultPtr fitResult = h.Fit(&gauss, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in
                                                      // the function range; S = save and return the fit result
 
-    if (fitResult->IsValid()) {
-        double energy = gaus.GetParameter(0);
-        double time = gaus.GetParameter(1);
-
-        return make_pair(time, energy);
-    } else {
-        // The fit failed
-        cout << endl
-             << "WARNING: bad fit to signal with ID " << GetID() << " with maximum at time = " << timeMax
-             << " ns " << endl
-             << "Failed fit parameters = " << gaus.GetParameter(0) << " || " << gaus.GetParameter(1) << " || "
-             << gaus.GetParameter(2) << endl;
-        /*
-        TCanvas* c2 = new TCanvas("c2", "Signal fit", 200, 10, 1280, 720);
-        h->Draw();
-        c2->Update();
-        getchar();
-        delete c2;
-        */
-
+    if (!fitResult->IsValid()) {
         return nullopt;
     }
+
+    double energy = gauss.GetParameter(0);
+    double time = gauss.GetParameter(1);
+
+    return make_pair(time, energy);
 }
 
 // z position by landau fit
@@ -402,24 +382,14 @@ TRestDetectorSignal::GetPeakLandau()  // returns a 2vector with the time of the 
     TFitResultPtr fitResult =
         h.Fit(&landau, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in the function range;
                                  // S = save and return the fit result
-    if (fitResult->IsValid()) {
-        double energy = landau.GetParameter(0);
-        double time = landau.GetParameter(1);
-        return make_pair(time, energy);
-    } else {
-        // the fit failed
-        cout << endl
-             << "WARNING: bad fit to signal with ID " << GetID() << " with maximum at time = " << maxRawTime
-             << " us " << endl;
-        /*
-        TCanvas* c2 = new TCanvas("c2", "Signal fit", 200, 10, 1280, 720);
-        h->Draw();
-        c2->Update();
-        getchar();
-        delete c2;
-        */
-        return std::nullopt;
+    if (!fitResult->IsValid()) {
+        return nullopt;
     }
+
+    double energy = landau.GetParameter(0);
+    double time = landau.GetParameter(1);
+
+    return make_pair(time, energy);
 }
 
 // z position by aget fit
@@ -477,17 +447,14 @@ TRestDetectorSignal::GetPeakAget()  // returns a 2vector with the time of the pe
     TFitResultPtr fitResult = h.Fit(&aget, "QNRS");  // Q = quiet, no info in screen; N = no plot; R = fit in
                                                      // the function range; S = save and return the fit result
 
-    if (fitResult->IsValid()) {
-        double energy = aget.GetParameter(0);
-        double time = aget.GetParameter(1);
-        return make_pair(time, energy);
-    } else {
-        // the fit failed
-        cout << endl
-             << "WARNING: bad fit to signal with ID " << GetID() << " with maximum at time = " << maxRawTime
-             << " ns " << endl;
+    if (!fitResult->IsValid()) {
         return nullopt;
     }
+
+    double energy = aget.GetParameter(0);
+    double time = aget.GetParameter(1);
+
+    return make_pair(time, energy);
 }
 
 Double_t TRestDetectorSignal::GetMaxPeakTime(Int_t from, Int_t to) { return GetTime(GetMaxIndex(from, to)); }

--- a/src/TRestDetectorSignalToHitsProcess.cxx
+++ b/src/TRestDetectorSignalToHitsProcess.cxx
@@ -390,6 +390,10 @@ TRestEvent* TRestDetectorSignalToHitsProcess::ProcessEvent(TRestEvent* inputEven
                 throw std::runtime_error("Invalid method");
             }
             if (!peak) {
+                if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Info) {
+                    cout << "Unable to find peak for signal " << signal->GetSignalID()
+                         << " with method: " << fMethod << endl;
+                }
                 continue;
             }
             const auto [time, energy] = peak.value();

--- a/src/TRestDetectorSignalToHitsProcess.cxx
+++ b/src/TRestDetectorSignalToHitsProcess.cxx
@@ -381,28 +381,19 @@ TRestEvent* TRestDetectorSignalToHitsProcess::ProcessEvent(TRestEvent* inputEven
         } else if (fMethod == "gaussFit") {
             const auto peak = signal->GetMaxGauss();
             if (peak) {
-                // unpack peak
-                const TVector2 gaussFit = peak.value();
-                Double_t hitTime = 0;
-                Double_t z = -1.0;
-                if (gaussFit.X() >= 0.0) {
-                    hitTime = gaussFit.X();
-                    Double_t distanceToPlane = hitTime * fDriftVelocity;
-                    z = zPosition + fieldZDirection * distanceToPlane;
-                }
-                Double_t energy = -1.0;
-                if (gaussFit.Y() >= 0.0) {
-                    energy = gaussFit.Y();
-                }
+                const auto [time, energy] = peak.value();
+
+                const auto distanceToPlane = time * fDriftVelocity;
+                const auto z = zPosition + fieldZDirection * distanceToPlane;
 
                 if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
                     cout << "Signal event : " << signal->GetSignalID()
                          << "--------------------------------------------------------" << endl;
-                    cout << "GausFit : time bin " << gaussFit.X() << " and energy : " << gaussFit.Y() << endl;
+                    cout << "GaussFit : time " << time << " ns and energy : " << energy << endl;
                     cout << "Signal to hit info : zPosition : " << zPosition
                          << "; fieldZDirection : " << fieldZDirection << " and driftV : " << fDriftVelocity
                          << endl;
-                    cout << "Adding hit. Time : " << hitTime << " x : " << x << " y : " << y << " z : " << z
+                    cout << "Adding hit. Time : " << time << " ns x : " << x << " y : " << y << " z : " << z
                          << " Energy : " << energy << endl;
                 }
             } else {

--- a/src/TRestDetectorSignalToHitsProcess.cxx
+++ b/src/TRestDetectorSignalToHitsProcess.cxx
@@ -404,11 +404,11 @@ TRestEvent* TRestDetectorSignalToHitsProcess::ProcessEvent(TRestEvent* inputEven
             if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
                 cout << "Signal event : " << signal->GetSignalID()
                      << "--------------------------------------------------------" << endl;
-                cout << "Method: " << fMethod << " : time " << time << " ns and energy : " << energy << endl;
+                cout << "Method: " << fMethod << " : time " << time << " us and energy : " << energy << endl;
                 cout << "Signal to hit info : zPosition : " << zPosition
                      << "; fieldZDirection : " << fieldZDirection << " and driftV : " << fDriftVelocity
                      << endl;
-                cout << "Adding hit. Time : " << time << " ns x : " << x << " y : " << y << " z : " << z
+                cout << "Adding hit. Time : " << time << " us x : " << x << " y : " << y << " z : " << z
                      << " Energy : " << energy << endl;
             }
 

--- a/src/TRestDetectorSignalToHitsProcess.cxx
+++ b/src/TRestDetectorSignalToHitsProcess.cxx
@@ -378,86 +378,37 @@ TRestEvent* TRestDetectorSignalToHitsProcess::ProcessEvent(TRestEvent* inputEven
                 cout << "E1, E2, E3 = " << energy1 << ", " << energy2 << ", " << energy3 << endl;
             }
 
-        } else if (fMethod == "gaussFit") {
-            const auto peak = signal->GetMaxGauss();
-            if (peak) {
-                const auto [time, energy] = peak.value();
-
-                const auto distanceToPlane = time * fDriftVelocity;
-                const auto z = zPosition + fieldZDirection * distanceToPlane;
-
-                if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
-                    cout << "Signal event : " << signal->GetSignalID()
-                         << "--------------------------------------------------------" << endl;
-                    cout << "GaussFit : time " << time << " ns and energy : " << energy << endl;
-                    cout << "Signal to hit info : zPosition : " << zPosition
-                         << "; fieldZDirection : " << fieldZDirection << " and driftV : " << fDriftVelocity
-                         << endl;
-                    cout << "Adding hit. Time : " << time << " ns x : " << x << " y : " << y << " z : " << z
-                         << " Energy : " << energy << endl;
-                }
+        } else if (fMethod == "gaussFit" || fMethod == "landauFit" || fMethod == "agetFit") {
+            optional<pair<Double_t, Double_t>> peak;
+            if (fMethod == "gaussFit") {
+                peak = signal->GetPeakGauss();
+            } else if (fMethod == "landauFit") {
+                peak = signal->GetPeakLandau();
+            } else if (fMethod == "agetFit") {
+                peak = signal->GetPeakAget();
             } else {
-                // Perhaps we should just skip it
-                double energy = -1;
-                double z = -1;
-                fHitsEvent->AddHit(x, y, z, energy, 0, type);
+                throw std::runtime_error("Invalid method");
             }
-        } else if (fMethod == "landauFit") {
-            TVector2 landauFit = signal->GetMaxLandau();
+            if (!peak) {
+                continue;
+            }
+            const auto [time, energy] = peak.value();
 
-            Double_t hitTime = 0;
-            Double_t z = -1.0;
-            if (landauFit.X() >= 0.0) {
-                hitTime = landauFit.X();
-                Double_t distanceToPlane = hitTime * fDriftVelocity;
-                z = zPosition + fieldZDirection * distanceToPlane;
-            }
-            Double_t energy = -1.0;
-            if (landauFit.Y() >= 0.0) {
-                energy = landauFit.Y();
-            }
+            const auto distanceToPlane = time * fDriftVelocity;
+            const auto z = zPosition + fieldZDirection * distanceToPlane;
 
             if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
                 cout << "Signal event : " << signal->GetSignalID()
                      << "--------------------------------------------------------" << endl;
-                cout << "landauFit : time bin " << landauFit.X() << " and energy : " << landauFit.Y() << endl;
+                cout << "Method: " << fMethod << " : time " << time << " ns and energy : " << energy << endl;
                 cout << "Signal to hit info : zPosition : " << zPosition
                      << "; fieldZDirection : " << fieldZDirection << " and driftV : " << fDriftVelocity
                      << endl;
-                cout << "Adding hit. Time : " << hitTime << " x : " << x << " y : " << y << " z : " << z
+                cout << "Adding hit. Time : " << time << " ns x : " << x << " y : " << y << " z : " << z
                      << " Energy : " << energy << endl;
             }
 
             fHitsEvent->AddHit(x, y, z, energy, 0, type);
-
-        } else if (fMethod == "agetFit") {
-            TVector2 agetFit = signal->GetMaxAget();
-
-            Double_t hitTime = 0;
-            Double_t z = -1.0;
-            if (agetFit.X() >= 0.0) {
-                hitTime = agetFit.X();
-                Double_t distanceToPlane = hitTime * fDriftVelocity;
-                z = zPosition + fieldZDirection * distanceToPlane;
-            }
-            Double_t energy = -1.0;
-            if (agetFit.Y() >= 0.0) {
-                energy = agetFit.Y();
-            }
-
-            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
-                cout << "Signal event : " << signal->GetSignalID()
-                     << "--------------------------------------------------------" << endl;
-                cout << "agetFit : time bin " << agetFit.X() << " and energy : " << agetFit.Y() << endl;
-                cout << "Signal to hit info : zPosition : " << zPosition
-                     << "; fieldZDirection : " << fieldZDirection << " and driftV : " << fDriftVelocity
-                     << endl;
-                cout << "Adding hit. Time : " << hitTime << " x : " << x << " y : " << y << " z : " << z
-                     << " Energy : " << energy << endl;
-            }
-
-            fHitsEvent->AddHit(x, y, z, energy, 0, type);
-
         } else if (fMethod == "qCenter") {
             Double_t energy_signal = 0;
             Double_t distanceToPlane = 0;
@@ -492,7 +443,7 @@ TRestEvent* TRestDetectorSignalToHitsProcess::ProcessEvent(TRestEvent* inputEven
             }
         } else if (fMethod == "intwindow") {
             Int_t nPoints = signal->GetNumberOfPoints();
-            std::map<int, std::pair<int, double> > windowMap;
+            std::map<int, std::pair<int, double>> windowMap;
             for (int j = 0; j < nPoints; j++) {
                 int index = signal->GetTime(j) / fIntWindow;
                 auto it = windowMap.find(index);


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 89](https://badgen.net/badge/PR%20Size/Ok%3A%2089/green) [![](https://github.com/rest-for-physics/detectorlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=lobis-option)](https://github.com/rest-for-physics/detectorlib/commits/lobis-option) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

New we skip the peak if it's not being found, instead of returning energy -1