### PR TITLE
Do not error on negative energy (why?)

### DIFF
--- a/src/TRestDetectorHitsReadoutAnalysisProcess.cxx
+++ b/src/TRestDetectorHitsReadoutAnalysisProcess.cxx
@@ -28,7 +28,7 @@ TRestEvent* TRestDetectorHitsReadoutAnalysisProcess::ProcessEvent(TRestEvent* in
             cerr << "TRestDetectorHitsReadoutAnalysisProcess::ProcessEvent() : "
                  << "Negative energy found in hit " << hitIndex << ". Energy (keV): " << energy << endl;
             // exit(1);
-            continue; // We should error, but for now we just skip the hit
+            continue;  // We should error, but for now we just skip the hit
         }
         // when working with hits derived from experimental data, only relative z is available, so it cannot
         // be used to check if a position is inside the readout. We use z=0 in this case which in most cases

--- a/src/TRestDetectorHitsReadoutAnalysisProcess.cxx
+++ b/src/TRestDetectorHitsReadoutAnalysisProcess.cxx
@@ -24,10 +24,11 @@ TRestEvent* TRestDetectorHitsReadoutAnalysisProcess::ProcessEvent(TRestEvent* in
         if (energy == 0) {
             continue;
         } else if (energy < 0) {
-            // this should never happen
+            // This should never happen. Why does it happen?
             cerr << "TRestDetectorHitsReadoutAnalysisProcess::ProcessEvent() : "
-                 << "Negative energy found in hit " << hitIndex << endl;
-            exit(1);
+                 << "Negative energy found in hit " << hitIndex << ". Energy (keV): " << energy << endl;
+            // exit(1);
+            continue; // We should error, but for now we just skip the hit
         }
         // when working with hits derived from experimental data, only relative z is available, so it cannot
         // be used to check if a position is inside the readout. We use z=0 in this case which in most cases


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 4](https://badgen.net/badge/PR%20Size/Ok%3A%204/green) [![](https://github.com/rest-for-physics/detectorlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=negative-energy)](https://github.com/rest-for-physics/detectorlib/commits/negative-energy) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This should never happen. The problem originates in Geant4 (most likely). Skip for now, but we should fix this in the future.