### PR TITLE
[codex] Use channel energy for hit smearing

### DIFF
--- a/src/TRestDetectorHitsSmearingProcess.cxx
+++ b/src/TRestDetectorHitsSmearingProcess.cxx
@@ -22,8 +22,9 @@
 
 //////////////////////////////////////////////////////////////////////////
 /// TRestDetectorHitsSmearingProcess will introduce a stochastic smearing on the
-/// energy of the hits for each event. The total energy of each event will be
-/// re-distributed following a gaussian shaped function.
+/// energy of the hits for each event. The total energy of the selected channel
+/// type in each event will be re-distributed following a gaussian shaped
+/// function.
 ///
 /// The energy resolution will follow a root square law with the energy
 /// using the `energyReference` and the `resolutionReference` as a pivoting
@@ -122,10 +123,21 @@ TRestEvent* TRestDetectorHitsSmearingProcess::ProcessEvent(TRestEvent* inputEven
     fInputEvent = (TRestDetectorHitsEvent*)inputEvent;
     fOutputEvent->SetEventInfo(fInputEvent);
 
-    Double_t eDep = fInputEvent->GetTotalEnergy();
-    Double_t eRes = fResolutionAtERef * TMath::Sqrt(fEnergyRef / eDep) / 2.35 / 100.0;
+    Double_t eDep = 0.0;
+    for (int hit = 0; hit < static_cast<int>(fInputEvent->GetNumberOfHits()); hit++) {
+        const auto hitType = fInputEvent->GetType(hit);
+        if ((fChannelType == "veto" && hitType == REST_HitType::VETO) ||
+            (fChannelType == "tpc" && hitType != REST_HitType::VETO)) {
+            eDep += fInputEvent->GetEnergy(hit);
+        }
+    }
 
-    Double_t gain = fRandom->Gaus(1.0, eRes);
+    Double_t gain = 1.0;
+    if (eDep > 0) {
+        Double_t eRes = fResolutionAtERef * TMath::Sqrt(fEnergyRef / eDep) / 2.35 / 100.0;
+        gain = fRandom->Gaus(1.0, eRes);
+    }
+
     for (int hit = 0; hit < static_cast<int>(fInputEvent->GetNumberOfHits()); hit++) {
         const auto hitType = fInputEvent->GetType(hit);
 


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 17](https://badgen.net/badge/PR%20Size/Ok%3A%2017/green) [![](https://github.com/rest-for-physics/detectorlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=codex/channel-specific-hit-smearing)](https://github.com/rest-for-physics/detectorlib/commits/codex/channel-specific-hit-smearing) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

## Summary

- Compute the smearing resolution from the energy in the selected channel type instead of the total detector-hit energy.
- Keep the previous behavior for applying one common stochastic gain to the selected TPC or VETO hits.
- Leave non-selected hit types unchanged and avoid drawing a smearing factor when the selected channel has zero energy.

## Why

`TRestDetectorHitsSmearingProcess` can be configured with `channelType=tpc` or `channelType=veto`, but the resolution was derived from `fInputEvent->GetTotalEnergy()`. For mixed events containing both TPC and VETO hits, a large energy deposit in the other channel could bias the selected-channel resolution. This is especially visible in cosmic-background simulations where a small TPC deposit may coexist with a large veto deposit.

## Validation

- Ran `git diff --check` on the patch.
- Built the `RestDetector` target on the NAF REST build tree successfully. 