### PR TITLE
TRestDetectorElectronDiffusionProcess fix when several readout planes

### DIFF
--- a/src/TRestDetectorElectronDiffusionProcess.cxx
+++ b/src/TRestDetectorElectronDiffusionProcess.cxx
@@ -243,13 +243,13 @@ TRestEvent* TRestDetectorElectronDiffusionProcess::ProcessEvent(TRestEvent* inpu
                     positionAfterDiffusion += {
                         fRandom->Gaus(0, transversalDiffusion),  //
                         fRandom->Gaus(0, transversalDiffusion),  //
-                        0                                      //
+                        0                                        //
                     };
                 }
                 if (longitudinalDiffusion > 0) {
                     positionAfterDiffusion += {
-                        0,  //
-                        0,  //
+                        0,                                       //
+                        0,                                       //
                         fRandom->Gaus(0, longitudinalDiffusion)  //
                     };
                 }
@@ -260,7 +260,8 @@ TRestEvent* TRestDetectorElectronDiffusionProcess::ProcessEvent(TRestEvent* inpu
                         plane->GetPosition().Z() +
                         1E-6 * plane->GetNormal().Z());  // add a delta to make sure readout finds it
                 }
-                if (plane->GetDistanceTo(positionAfterDiffusion) > plane->GetHeight() && longitudinalDiffusion > 0) {
+                if (plane->GetDistanceTo(positionAfterDiffusion) > plane->GetHeight() &&
+                    longitudinalDiffusion > 0) {
                     // electron has been moved over the plane
                     positionAfterDiffusion.SetZ(
                         plane->GetPosition().Z() + plane->GetHeight() -
@@ -283,7 +284,7 @@ TRestEvent* TRestDetectorElectronDiffusionProcess::ProcessEvent(TRestEvent* inpu
                 }
                 fOutputHitsEvent->AddHit(positionAfterDiffusion.X(), positionAfterDiffusion.Y(),
                                          positionAfterDiffusion.Z(), electronEnergy, time, type);
-                break; // avoid redoing for other planes (happens if fCheckIsInside is false)
+                break;  // avoid redoing for other planes (happens if fCheckIsInside is false)
             }
         }
     }

--- a/src/TRestDetectorElectronDiffusionProcess.cxx
+++ b/src/TRestDetectorElectronDiffusionProcess.cxx
@@ -58,6 +58,7 @@ void TRestDetectorElectronDiffusionProcess::Initialize() {
     fReadout = nullptr;
 
     fRandom = nullptr;
+    fCheckIsInside = true;
 }
 
 void TRestDetectorElectronDiffusionProcess::LoadConfig(const string& configFilename, const string& name) {
@@ -319,6 +320,6 @@ void TRestDetectorElectronDiffusionProcess::InitFromConfigFile() {
     fSeed = static_cast<UInt_t>(StringToInteger(GetParameter("seed", "0")));
     fPoissonElectronExcitation = StringToBool(GetParameter("poissonElectronExcitation", "true"));
     fUnitElectronEnergy = StringToBool(GetParameter("unitElectronEnergy", "false"));
-    fCheckIsInside = StringToBool(GetParameter("checkIsInside", "false"));
+    fCheckIsInside = StringToBool(GetParameter("checkIsInside", "true"));
     fUseFanoFactor = StringToBool(GetParameter("useFano", "false"));
 }

--- a/src/TRestDetectorElectronDiffusionProcess.cxx
+++ b/src/TRestDetectorElectronDiffusionProcess.cxx
@@ -185,7 +185,7 @@ TRestEvent* TRestDetectorElectronDiffusionProcess::ProcessEvent(TRestEvent* inpu
         const Double_t z = hits->GetZ(hitIndex);
 
         for (int p = 0; p < fReadout->GetNumberOfReadoutPlanes(); p++) {
-            TRestDetectorReadoutPlane* plane = &(*fReadout)[p];
+            TRestDetectorReadoutPlane* plane = fReadout->GetReadoutPlane(p);
             const auto planeType = plane->GetType();
             if (planeType == "veto") {
                 // do not drift veto planes

--- a/src/TRestDetectorElectronDiffusionProcess.cxx
+++ b/src/TRestDetectorElectronDiffusionProcess.cxx
@@ -46,8 +46,8 @@ void TRestDetectorElectronDiffusionProcess::Initialize() {
     fAttachment = 0;
     fGasPressure = -1;
 
-    fTransversalDiffusionCoefficient = 0;
-    fLongitudinalDiffusionCoefficient = 0;
+    fTransversalDiffusionCoefficient = -1;
+    fLongitudinalDiffusionCoefficient = -1;
     fWValue = 0;
     fFanoFactor = 0;
 
@@ -117,11 +117,11 @@ void TRestDetectorElectronDiffusionProcess::InitProcess() {
             fFanoFactor = fGas->GetGasFanoFactor();
         }
 
-        if (fLongitudinalDiffusionCoefficient <= 0) {
+        if (fLongitudinalDiffusionCoefficient < 0) {
             fLongitudinalDiffusionCoefficient = fGas->GetLongitudinalDiffusion();
         }  // (cm)^1/2
 
-        if (fTransversalDiffusionCoefficient <= 0) {
+        if (fTransversalDiffusionCoefficient < 0) {
             fTransversalDiffusionCoefficient = fGas->GetTransversalDiffusion();
         }  // (cm)^1/2
     }
@@ -239,18 +239,28 @@ TRestEvent* TRestDetectorElectronDiffusionProcess::ProcessEvent(TRestEvent* inpu
                 }
 
                 TVector3 positionAfterDiffusion = {x, y, z};
-                positionAfterDiffusion += {
-                    fRandom->Gaus(0, transversalDiffusion),  //
-                    fRandom->Gaus(0, transversalDiffusion),  //
-                    fRandom->Gaus(0, longitudinalDiffusion)  //
-                };
-                if (plane->GetDistanceTo(positionAfterDiffusion) < 0) {
+                if (transversalDiffusion > 0) {
+                    positionAfterDiffusion += {
+                        fRandom->Gaus(0, transversalDiffusion),  //
+                        fRandom->Gaus(0, transversalDiffusion),  //
+                        0                                      //
+                    };
+                }
+                if (longitudinalDiffusion > 0) {
+                    positionAfterDiffusion += {
+                        0,  //
+                        0,  //
+                        fRandom->Gaus(0, longitudinalDiffusion)  //
+                    };
+                }
+
+                if (plane->GetDistanceTo(positionAfterDiffusion) < 0 && longitudinalDiffusion > 0) {
                     // electron has been moved under the plane
                     positionAfterDiffusion.SetZ(
                         plane->GetPosition().Z() +
                         1E-6 * plane->GetNormal().Z());  // add a delta to make sure readout finds it
                 }
-                if (plane->GetDistanceTo(positionAfterDiffusion) > plane->GetHeight()) {
+                if (plane->GetDistanceTo(positionAfterDiffusion) > plane->GetHeight() && longitudinalDiffusion > 0) {
                     // electron has been moved over the plane
                     positionAfterDiffusion.SetZ(
                         plane->GetPosition().Z() + plane->GetHeight() -

--- a/src/TRestDetectorElectronDiffusionProcess.cxx
+++ b/src/TRestDetectorElectronDiffusionProcess.cxx
@@ -283,6 +283,7 @@ TRestEvent* TRestDetectorElectronDiffusionProcess::ProcessEvent(TRestEvent* inpu
                 }
                 fOutputHitsEvent->AddHit(positionAfterDiffusion.X(), positionAfterDiffusion.Y(),
                                          positionAfterDiffusion.Z(), electronEnergy, time, type);
+                break; // avoid redoing for other planes (happens if fCheckIsInside is false)
             }
         }
     }


### PR DESCRIPTION
![AlvaroEzq](https://badgen.net/badge/PR%20submitted%20by%3A/AlvaroEzq/blue) ![Ok: 26](https://badgen.net/badge/PR%20Size/Ok%3A%2026/green) [![](https://github.com/rest-for-physics/detectorlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=aezq_fixEDiff)](https://github.com/rest-for-physics/detectorlib/commits/aezq_fixEDiff) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

checkIsInside parameter seems to be true by default but not when initfromconfigfile. Fix this

also, when the readout has several planes and checkisinside is false, the hit is processed for every plane causing duplication of hits and hits with wrong z pos.