### PR TITLE
Fix hits event small event binning

### DIFF
--- a/src/TRestDetectorHitsEvent.cxx
+++ b/src/TRestDetectorHitsEvent.cxx
@@ -39,6 +39,8 @@
 ///
 #include "TRestDetectorHitsEvent.h"
 
+#include <array>
+
 #include "TCanvas.h"
 #include "TColor.h"
 #include "TH3F.h"
@@ -48,8 +50,6 @@
 #include "TRestStringHelper.h"
 #include "TRestTools.h"
 #include "TStyle.h"
-
-#include <array>
 
 using namespace std;
 using namespace TMath;
@@ -960,8 +960,8 @@ void TRestDetectorHitsEvent::DrawHistograms(Int_t& column, const TString& histOp
         // by the pad (kCanDelete) so they are freed when fPad is recreated on next DrawEvent.
         fPad->cd(3 + 3 * column);
 
-        TH3F* frame = new TH3F("XYZframe", "3D hits;X-axis (mm);Y-axis (mm);Z-axis (mm)", 1, minX,
-                               maxX, 1, minY, maxY, 1, minZ, maxZ);
+        TH3F* frame = new TH3F("XYZframe", "3D hits;X-axis (mm);Y-axis (mm);Z-axis (mm)", 1, minX, maxX, 1,
+                               minY, maxY, 1, minZ, maxZ);
         frame->SetDirectory(nullptr);
         frame->SetStats(false);
         frame->SetBit(kCanDelete);

--- a/src/TRestDetectorHitsEvent.cxx
+++ b/src/TRestDetectorHitsEvent.cxx
@@ -624,7 +624,7 @@ TPad* TRestDetectorHitsEvent::DrawEvent(const TString& option) {
 
     /// The default histogram using a pitch of 0 mm,
     //  which means that it should be extracted from the hit array
-    if (optList.size() == 0) optList.push_back("hist(Cont1,col)[3]");
+    if (optList.size() == 0) optList.push_back("hist(Cont1,col)");
 
     if (fPad != nullptr) {
         delete fPad;

--- a/src/TRestDetectorHitsEvent.cxx
+++ b/src/TRestDetectorHitsEvent.cxx
@@ -40,10 +40,16 @@
 #include "TRestDetectorHitsEvent.h"
 
 #include "TCanvas.h"
+#include "TColor.h"
+#include "TH3F.h"
+#include "TPolyLine3D.h"
+#include "TPolyMarker3D.h"
 #include "TRandom.h"
 #include "TRestStringHelper.h"
 #include "TRestTools.h"
 #include "TStyle.h"
+
+#include <array>
 
 using namespace std;
 using namespace TMath;
@@ -635,6 +641,14 @@ TPad* TRestDetectorHitsEvent::DrawEvent(const TString& option) {
     fPad->Divide(3, 2 * optList.size());
     fPad->Draw();
 
+    // Give each sub-pad enough margin so the axis titles (in particular the bottom-row
+    // x-axis titles and the wider 2-digit y-axis labels) are not clipped at the edges.
+    for (int i = 1; i <= 6 * (int)optList.size(); i++) {
+        fPad->cd(i);
+        gPad->SetBottomMargin(0.13);
+        gPad->SetLeftMargin(0.15);
+    }
+
     Int_t column = 0;
     for (unsigned int n = 0; n < optList.size(); n++) {
         string optionStr = (string)optList[n];
@@ -934,6 +948,80 @@ void TRestDetectorHitsEvent::DrawHistograms(Int_t& column, const TString& histOp
         fXYHisto->GetYaxis()->SetLabelSize(1.25 * fXYHisto->GetYaxis()->GetLabelSize());
         fXYHisto->GetXaxis()->SetLabelSize(1.25 * fXYHisto->GetXaxis()->GetLabelSize());
         fXYHisto->GetYaxis()->SetTitleOffset(1);
+    } else {
+        // When there is no XY projection (a strip readout, where hits are XZ/YZ) the pad is
+        // otherwise empty, so we use it for a 3D view of the event. A strip hit has one
+        // undetermined coordinate, so it is drawn as a line spanning that axis (XZ -> line
+        // along Y, YZ -> along X, XY -> along Z), colored by energy. An XZ and a YZ line
+        // cross in 3D where they share the same Z; that crossing (x_from_XZ, y_from_YZ, z)
+        // is the reconstructed hit position, so we highlight it with a marker, which sketches
+        // the event in 3D. (With several strips at the same Z these crossings also include
+        // ambiguous "ghost" combinations, inherent to strip readouts.) All objects are owned
+        // by the pad (kCanDelete) so they are freed when fPad is recreated on next DrawEvent.
+        fPad->cd(3 + 3 * column);
+
+        TH3F* frame = new TH3F("XYZframe", "3D hits;X-axis (mm);Y-axis (mm);Z-axis (mm)", 1, minX,
+                               maxX, 1, minY, maxY, 1, minZ, maxZ);
+        frame->SetDirectory(nullptr);
+        frame->SetStats(false);
+        frame->SetBit(kCanDelete);
+        frame->Draw();
+
+        Double_t eMin = 1e9, eMax = -1e9;
+        for (unsigned int nhit = 0; nhit < GetNumberOfHits(); nhit++) {
+            Double_t e = fHits->GetEnergy(nhit);
+            if (e < eMin) eMin = e;
+            if (e > eMax) eMax = e;
+        }
+        const Int_t nColors = TColor::GetNumberOfColors();
+        auto energyColor = [&](Double_t e) {
+            Int_t ci = (eMax > eMin) ? (Int_t)((e - eMin) / (eMax - eMin) * (nColors - 1)) : 0;
+            return TColor::GetColorPalette(ci);
+        };
+
+        std::vector<std::array<Double_t, 3>> xzHits;  // {x, z, energy}
+        std::vector<std::array<Double_t, 3>> yzHits;  // {y, z, energy}
+        for (unsigned int nhit = 0; nhit < GetNumberOfHits(); nhit++) {
+            Double_t x = fHits->GetX(nhit);
+            Double_t y = fHits->GetY(nhit);
+            Double_t z = fHits->GetZ(nhit);
+            Double_t en = fHits->GetEnergy(nhit);
+            int type = fHits->GetType(nhit);
+            bool hasX = (type % X == 0);
+            bool hasY = (type % Y == 0);
+
+            TPolyLine3D* line = new TPolyLine3D(2);
+            if (!hasX) {  // undetermined X (e.g. YZ hit): line along X
+                line->SetPoint(0, minX, y, z);
+                line->SetPoint(1, maxX, y, z);
+                yzHits.push_back({y, z, en});
+            } else if (!hasY) {  // undetermined Y (e.g. XZ hit): line along Y
+                line->SetPoint(0, x, minY, z);
+                line->SetPoint(1, x, maxY, z);
+                xzHits.push_back({x, z, en});
+            } else {  // undetermined Z (e.g. XY hit): line along Z
+                line->SetPoint(0, x, y, minZ);
+                line->SetPoint(1, x, y, maxZ);
+            }
+            line->SetLineColor(energyColor(en));
+            line->SetBit(kCanDelete);
+            line->Draw();
+        }
+
+        // Highlight the XZ/YZ crossings (same Z) -> reconstructed 3D positions of the event.
+        const Double_t zTol = 0.05 * (maxZ - minZ);
+        for (const auto& xz : xzHits) {
+            for (const auto& yz : yzHits) {
+                if (std::abs(xz[1] - yz[1]) > zTol) continue;
+                TPolyMarker3D* marker = new TPolyMarker3D(1);
+                marker->SetPoint(0, xz[0], yz[0], 0.5 * (xz[1] + yz[1]));
+                marker->SetMarkerStyle(20);
+                marker->SetMarkerSize(1.2);
+                marker->SetMarkerColor(energyColor(0.5 * (xz[2] + yz[2])));
+                marker->SetBit(kCanDelete);
+                marker->Draw();
+            }
+        }
     }
 
     column++;

--- a/src/TRestDetectorHitsEvent.cxx
+++ b/src/TRestDetectorHitsEvent.cxx
@@ -805,15 +805,32 @@ void TRestDetectorHitsEvent::DrawHistograms(Int_t& column, const TString& histOp
 
     double maxX, minX, maxY, minY, maxZ, minZ;
     int nBinsX, nBinsY, nBinsZ;
-    TRestHits::GetBoundaries(fX, maxX, minX, nBinsX);
-    TRestHits::GetBoundaries(fY, maxY, minY, nBinsY);
-    TRestHits::GetBoundaries(fZ, maxZ, minZ, nBinsZ);
+    // GetBoundaries reads dist.front()/back(), which is undefined for an empty projection
+    // (e.g. an event with no hits of a given type). Guard it so DrawEvent never crashes.
+    auto getBoundaries = [](std::vector<double>& v, double& mx, double& mn, int& nb) {
+        if (v.empty()) {
+            mn = -1;
+            mx = 1;
+            nb = 1;
+            return;
+        }
+        TRestHits::GetBoundaries(v, mx, mn, nb);
+    };
+    getBoundaries(fX, maxX, minX, nBinsX);
+    getBoundaries(fY, maxY, minY, nBinsY);
+    getBoundaries(fZ, maxZ, minZ, nBinsZ);
 
     if (pitch > 0) {
         nBinsX = std::round((maxX - minX) / pitch);
         nBinsY = std::round((maxY - minY) / pitch);
         nBinsZ = std::round((maxZ - minZ) / pitch);
     }
+
+    // A histogram needs at least one bin; ensure we never request 0 bins for a degenerate
+    // event (all hits sharing a coordinate, or a sub-pitch extent when a pitch is given).
+    nBinsX = std::max(1, nBinsX);
+    nBinsY = std::max(1, nBinsY);
+    nBinsZ = std::max(1, nBinsZ);
 
     delete fXYHisto;
     delete fXZHisto;


### PR DESCRIPTION
![cmargalejo](https://badgen.net/badge/PR%20submitted%20by%3A/cmargalejo/blue) ![Medium: 109](https://badgen.net/badge/PR%20Size/Medium%3A%20109/orange) [![](https://github.com/rest-for-physics/detectorlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=cris_fix_hitsEvent_smallevent_binning)](https://github.com/rest-for-physics/detectorlib/commits/cris_fix_hitsEvent_smallevent_binning) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

## Summary

The event browser drew small, localized `TRestDetectorHitsEvent`s (e.g. X-ray
calibration hits) as solid colored vertical bands instead of a recognizable hit
cluster. This PR fixes that, hardens the drawing code, and improves the
`DrawEvent` layout.

## What changed (3 commits)

1. **Revert default DrawEvent pitch to use the existing adaptive binning**
   Reverts commit `5c7b983d`, which set the default option to `hist(Cont1,col)[3]`.
   The `[3]` forces a 3 mm bin pitch, so `nBins = round(range/3)` rounds to 0–1 bins
   for events smaller than 3 mm, collapsing them into a single band. Removing it
   restores the adaptive binning that `TRestHits::GetBoundaries` already computes.
   ⚠️ I could not find the original purpose of the `[3]` pitch. **If anyone knows
   why it was added, or disagrees with this revert, please let me know.**

2. **Guard DrawHistograms against degenerate events**
   `GetBoundaries` reads `front()/back()`, undefined for an empty projection (an
   event with no hits of a given type) — a latent crash. Also clamp `nBins >= 1`.
   No effect on normal events.

3. **Fix pad layout and add a 3D view for strip events**
   Add sub-pad margins so axis titles are no longer cut off (most visibly the
   bottom-right Z histogram). When there is no XY projection (strip readouts with
   XZ/YZ hits), use the otherwise-empty top-right pad for a 3D view: each strip hit
   is a line along its undetermined axis (XZ→Y, YZ→X, XY→Z), colored by energy, and
   the XZ/YZ crossings (reconstructed hit positions) are marked with dots — which
   draws the event in 3D.

## Notes

- Scope is the viewer only (`DrawEvent` / `DrawHistograms`); the analysis-facing
  `GetXYHistogram` / `GetXZHistogram` / `GetYZHistogram` are untouched.
- The 3D crossing markers include ambiguous "ghost" combinations for
  high-multiplicity events — inherent to strip readouts, not a bug.

## Before / after

**Before** — a small X-ray event (572900) collapses into solid vertical bands, and the
bottom-right Z histogram is clipped:

<img width="1919" height="1079" alt="Screenshot 2026-06-18 111625" src="https://github.com/user-attachments/assets/9b4afca3-bdcf-4ba4-8444-a57489c98c30" />


**After** — same event: adaptive binning, full axis titles, and the new 3D view with the
strip-crossing markers (reconstructed positions):

<img width="1907" height="1027" alt="Screenshot 2026-06-19 182435" src="https://github.com/user-attachments/assets/4d019e35-9463-472b-8267-60aeaed12820" />


**After** — an alpha event: the 3D crossings trace out the track cloud:

<img width="1911" height="1027" alt="Screenshot 2026-06-19 182538" src="https://github.com/user-attachments/assets/c771175b-39ef-4f17-a7a1-b517779e5247" /> 